### PR TITLE
Add feature OSD to supported targets

### DIFF
--- a/configs/default/AIKONF4.config
+++ b/configs/default/AIKONF4.config
@@ -99,6 +99,9 @@ dma pin A01 0
 dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/AIRBOTF7.config
+++ b/configs/default/AIRBOTF7.config
@@ -67,6 +67,9 @@ dma pin C09 0
 dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
+# feature
+feature OSD
+
 # master
 set blackbox_device = SPIFLASH
 set dshot_burst = ON

--- a/configs/default/AIRF7.config
+++ b/configs/default/AIRF7.config
@@ -69,6 +69,9 @@ dma pin B00 0
 dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/ALIENFLIGHTNGF7.config
+++ b/configs/default/ALIENFLIGHTNGF7.config
@@ -62,6 +62,7 @@ set flash_spi_bus = 2
 # OSD
 resource OSD_CS 1 B12
 set max7456_spi_bus = 3
+feature OSD
 
 # Timers
 timer A08 AF1

--- a/configs/default/ALIENFLIGHTNGF7_DUAL.config
+++ b/configs/default/ALIENFLIGHTNGF7_DUAL.config
@@ -52,6 +52,7 @@ dma SPI_TX 2 0
 # OSD
 resource OSD_CS 1 B12
 set max7456_spi_bus = 3
+feature OSD
 
 # Timers
 timer A08 AF1

--- a/configs/default/BEEROTORF4.config
+++ b/configs/default/BEEROTORF4.config
@@ -94,6 +94,9 @@ dma pin B05 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/CLRACINGF4.config
+++ b/configs/default/CLRACINGF4.config
@@ -77,6 +77,9 @@ dma pin B04 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set blackbox_device = SDCARD
 set motor_pwm_protocol = DSHOT600

--- a/configs/default/DYSF4PRO.config
+++ b/configs/default/DYSF4PRO.config
@@ -103,6 +103,9 @@ dma pin A09 0
 dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/EXF722DUAL.config
+++ b/configs/default/EXF722DUAL.config
@@ -103,6 +103,7 @@ dma pin A01 0
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
+feature OSD
 
 # serial
 serial 20 1 115200 57600 0 115200

--- a/configs/default/FOXEERF722DUAL.config
+++ b/configs/default/FOXEERF722DUAL.config
@@ -88,6 +88,9 @@ dma pin A15 0
 dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/HAKRCF411.config
+++ b/configs/default/HAKRCF411.config
@@ -72,6 +72,10 @@ dma pin B03 0
 dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
+
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/HGLRCF405.config
+++ b/configs/default/HGLRCF405.config
@@ -101,6 +101,9 @@ dma pin A10 0
 dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
+# feature
+feature OSD
+
 # master
 set gyro_to_use = FIRST
 set align_mag = DEFAULT

--- a/configs/default/HGLRCF405AS.config
+++ b/configs/default/HGLRCF405AS.config
@@ -104,6 +104,9 @@ dma pin A09 0
 dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/HGLRCF411.config
+++ b/configs/default/HGLRCF411.config
@@ -75,6 +75,9 @@ dma pin A02 0
 dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set min_throttle = 1070
 set use_unsynced_pwm = OFF

--- a/configs/default/HGLRCF745.config
+++ b/configs/default/HGLRCF745.config
@@ -101,6 +101,9 @@ dma pin C07 1
 dma pin A03 0
 # pin A03: DMA1 Stream 7 Channel 3
 
+# feature
+feature OSD
+
 # master
 set gyro_to_use = FIRST
 set align_mag = DEFAULT

--- a/configs/default/IFF411_PRO.config
+++ b/configs/default/IFF411_PRO.config
@@ -63,6 +63,9 @@ dma pin B07 0
 dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/IFF411_TWING.config
+++ b/configs/default/IFF411_TWING.config
@@ -63,6 +63,9 @@ dma pin B07 0
 dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set gyro_to_use = BOTH
 set mag_hardware = NONE

--- a/configs/default/IFF7_TWIN_G.config
+++ b/configs/default/IFF7_TWIN_G.config
@@ -103,6 +103,7 @@ dma pin A01 0
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
+feature OSD
 
 # serial
 serial 1 64 115200 57600 0 115200

--- a/configs/default/JHEF7DUAL.config
+++ b/configs/default/JHEF7DUAL.config
@@ -90,6 +90,9 @@ dma pin A08 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1

--- a/configs/default/KAKUTEF7.config
+++ b/configs/default/KAKUTEF7.config
@@ -86,6 +86,9 @@ dma pin A03 0
 dma pin D12 0
 # pin D12: DMA1 Stream 0 Channel 2
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/KAKUTEF7MINI.config
+++ b/configs/default/KAKUTEF7MINI.config
@@ -83,6 +83,9 @@ dma pin A03 0
 dma pin D12 0
 # pin D12: DMA1 Stream 0 Channel 2
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MATEKF405CTR.config
+++ b/configs/default/MATEKF405CTR.config
@@ -104,6 +104,9 @@ dma pin A00 0
 dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MATEKF405MINI.config
+++ b/configs/default/MATEKF405MINI.config
@@ -105,6 +105,7 @@ dma pin A01 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 1 64 115200 57600 0 115200

--- a/configs/default/MATEKF405STD.config
+++ b/configs/default/MATEKF405STD.config
@@ -104,6 +104,9 @@ dma pin A00 0
 dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MATEKF411RX.config
+++ b/configs/default/MATEKF411RX.config
@@ -82,6 +82,7 @@ dma pin A10 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SPI
+feature OSD
 
 # master
 set rx_spi_protocol = FRSKY_X

--- a/configs/default/MATEKF722.config
+++ b/configs/default/MATEKF722.config
@@ -103,6 +103,9 @@ dma pin A01 0
 dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MATEKF722MINI.config
+++ b/configs/default/MATEKF722MINI.config
@@ -112,6 +112,7 @@ dma pin A00 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 1 64 115200 57600 0 115200

--- a/configs/default/MATEKF722SE.config
+++ b/configs/default/MATEKF722SE.config
@@ -111,6 +111,9 @@ dma pin A01 0
 dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MERAKRCF405.config
+++ b/configs/default/MERAKRCF405.config
@@ -85,6 +85,9 @@ dma pin B01 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MERAKRCF722.config
+++ b/configs/default/MERAKRCF722.config
@@ -84,6 +84,9 @@ dma pin B01 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/MLTEMPF4.config
+++ b/configs/default/MLTEMPF4.config
@@ -79,6 +79,9 @@ dma pin A08 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set blackbox_device = SDCARD
 set current_meter = ADC

--- a/configs/default/MLTYPHF4.config
+++ b/configs/default/MLTYPHF4.config
@@ -80,6 +80,9 @@ dma pin A08 0
 dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
+# feature
+feature OSD
+
 # master
 set blackbox_device = SDCARD
 set current_meter = ADC

--- a/configs/default/MODULARF4.config
+++ b/configs/default/MODULARF4.config
@@ -84,6 +84,7 @@ dma pin A00 0
 
 
 # feature
+feature OSD
 
 # beeper
 

--- a/configs/default/OMNIBUSF4.config
+++ b/configs/default/OMNIBUSF4.config
@@ -104,6 +104,9 @@ dma pin A09 0
 dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/OMNIBUSF4FW.config
+++ b/configs/default/OMNIBUSF4FW.config
@@ -103,6 +103,7 @@ dma pin A01 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 5 64 115200 57600 0 115200

--- a/configs/default/OMNIBUSF4NANOV7.config
+++ b/configs/default/OMNIBUSF4NANOV7.config
@@ -72,6 +72,7 @@ dma pin B07 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 0 64 115200 57600 0 115200

--- a/configs/default/OMNIBUSF4SD.config
+++ b/configs/default/OMNIBUSF4SD.config
@@ -118,6 +118,7 @@ dma pin A10 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 5 64 115200 57600 0 115200

--- a/configs/default/OMNIBUSF4V6.config
+++ b/configs/default/OMNIBUSF4V6.config
@@ -103,6 +103,7 @@ dma pin A01 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 5 64 115200 57600 0 115200

--- a/configs/default/OMNIBUSF7NANOV7.config
+++ b/configs/default/OMNIBUSF7NANOV7.config
@@ -71,6 +71,7 @@ dma pin B07 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature OSD
 
 # serial
 serial 0 64 115200 57600 0 115200

--- a/configs/default/OMNIBUSF7V2.config
+++ b/configs/default/OMNIBUSF7V2.config
@@ -101,6 +101,9 @@ dma pin C07 1
 dma pin A03 0
 # pin A03: DMA1 Stream 7 Channel 3
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/RUSHCORE7.config
+++ b/configs/default/RUSHCORE7.config
@@ -81,6 +81,9 @@ dma pin B11 0
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/SPEDIXF4.config
+++ b/configs/default/SPEDIXF4.config
@@ -97,6 +97,9 @@ dma pin A15 0
 dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/SPEEDYBEEF4.config
+++ b/configs/default/SPEEDYBEEF4.config
@@ -89,6 +89,9 @@ dma pin B08 0
 dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1

--- a/configs/default/SPRACINGF7DUAL.config
+++ b/configs/default/SPRACINGF7DUAL.config
@@ -131,6 +131,9 @@ dma pin A09 1
 dma pin A10 1
 # pin A10: DMA2 Stream 6 Channel 6
 
+# feature
+feature OSD
+
 # master
 set gyro_to_use = BOTH
 set mag_bustype = I2C

--- a/configs/default/TMOTORF4.config
+++ b/configs/default/TMOTORF4.config
@@ -97,6 +97,9 @@ dma pin A15 0
 dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/TMOTORF7.config
+++ b/configs/default/TMOTORF7.config
@@ -86,6 +86,9 @@ dma pin A15 0
 dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
+# feature
+feature OSD
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 2

--- a/configs/default/VGOODRCF4.config
+++ b/configs/default/VGOODRCF4.config
@@ -88,6 +88,9 @@ dma pin C09 0
 dma pin A08 1
 # pin A08: DMA2 Stream 1 Channel 6
 
+# feature
+feature OSD
+
 # master
 set gyro_to_use = FIRST
 set align_mag = DEFAULT

--- a/configs/default/VIVAF4AIO.config
+++ b/configs/default/VIVAF4AIO.config
@@ -85,6 +85,8 @@ dma pin B06 0
 dma pin A05 0
 # pin A05: DMA1 Stream 5 Channel 3
 
+# feature
+feature OSD
 
 # master
 set mag_bustype = I2C

--- a/configs/default/XILOF4.config
+++ b/configs/default/XILOF4.config
@@ -75,6 +75,7 @@ dma pin B07 0
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature ESC_SENSOR
+feature OSD
 
 # serial
 serial 0 64 115200 57600 0 115200


### PR DESCRIPTION
Enabled `feature OSD` for targets which have OSD parameters set up in the config.