### PR TITLE
Mitigating problem when using 'defaults nosave' with RX feature defined in the custom defaults.

### DIFF
--- a/configs/default/ALIENFLIGHTF4.config
+++ b/configs/default/ALIENFLIGHTF4.config
@@ -141,7 +141,7 @@ resource RX_BIND_PLUG 1 B02
 resource ESCSERIAL 1 A08
 
 # Some configs
-feature RX_SERIAL
+#feature RX_SERIAL
 feature MOTOR_STOP
 map TAER1234
 serial 0 0 115200 57600 0 115200

--- a/configs/default/ALIENFLIGHTNGF7.config
+++ b/configs/default/ALIENFLIGHTNGF7.config
@@ -142,7 +142,7 @@ resource RX_BIND_PLUG 1 B02
 resource ESCSERIAL 1 A08
 
 # Some configs
-feature RX_SERIAL
+#feature RX_SERIAL
 feature MOTOR_STOP
 map TAER1234
 serial 0 0 115200 57600 0 115200

--- a/configs/default/ALIENFLIGHTNGF7_DUAL.config
+++ b/configs/default/ALIENFLIGHTNGF7_DUAL.config
@@ -132,7 +132,7 @@ resource RX_BIND_PLUG 1 B02
 resource ESCSERIAL 1 A08
 
 # Some configs
-feature RX_SERIAL
+#feature RX_SERIAL
 feature MOTOR_STOP
 map TAER1234
 serial 0 0 115200 57600 0 115200

--- a/configs/default/CLRACINGF7.config
+++ b/configs/default/CLRACINGF7.config
@@ -71,7 +71,7 @@ dma pin C09 0    # pin C09: DMA2 Stream 7 Channel 7
 dma pin B01 0    # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/ELINF405.config
+++ b/configs/default/ELINF405.config
@@ -94,7 +94,7 @@ dma pin B07 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/ELINF722.config
+++ b/configs/default/ELINF722.config
@@ -93,7 +93,7 @@ dma pin B07 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/EXF722DUAL.config
+++ b/configs/default/EXF722DUAL.config
@@ -101,7 +101,7 @@ dma pin A01 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD
 

--- a/configs/default/FF_RACEPIT.config
+++ b/configs/default/FF_RACEPIT.config
@@ -104,7 +104,7 @@ resource ADC_CURR 1 C01
 resource ESCSERIAL 1 B00
 
 # Some configs
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 serial 0 0 115200 57600 0 115200
 serial 1 0 115200 57600 0 115200

--- a/configs/default/FF_RACEPIT_MINI.config
+++ b/configs/default/FF_RACEPIT_MINI.config
@@ -103,7 +103,7 @@ resource ADC_CURR 1 C01
 resource ESCSERIAL 1 B00
 
 # Some configs
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 serial 0 0 115200 57600 0 115200
 serial 1 0 115200 57600 0 115200

--- a/configs/default/FLYWOOF405.config
+++ b/configs/default/FLYWOOF405.config
@@ -94,7 +94,7 @@ dma pin A09 0
 # pin A09: DMA2 Stream 6 Channel 0
 
 # feature
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP
 feature OSD

--- a/configs/default/FLYWOOF411.config
+++ b/configs/default/FLYWOOF411.config
@@ -84,7 +84,7 @@ dma pin A15 0
 
 # feature
 feature SOFTSERIAL
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP
 feature OSD

--- a/configs/default/FLYWOOF7DUAL.config
+++ b/configs/default/FLYWOOF7DUAL.config
@@ -109,7 +109,7 @@ dma pin A03 1
 
 # feature
 feature SOFTSERIAL
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature RSSI_ADC
 feature LED_STRIP

--- a/configs/default/FURYF4OSD.config
+++ b/configs/default/FURYF4OSD.config
@@ -76,7 +76,7 @@ dma pin A00 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/IFF4_TWIN_G.config
+++ b/configs/default/IFF4_TWIN_G.config
@@ -81,7 +81,7 @@ dma pin A00 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP
 feature DISPLAY

--- a/configs/default/IFF7_TWIN_G.config
+++ b/configs/default/IFF7_TWIN_G.config
@@ -101,7 +101,7 @@ dma pin A01 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD
 

--- a/configs/default/KAKUTEF4V2.config
+++ b/configs/default/KAKUTEF4V2.config
@@ -74,7 +74,7 @@ dma pin C08 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature OSD
 

--- a/configs/default/MAMBAF411.config
+++ b/configs/default/MAMBAF411.config
@@ -76,7 +76,7 @@ dma pin A08 0  # pin A08: DMA2 Stream 6 Channel 0
 
 # FEATURE
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MAMBAF722.config
+++ b/configs/default/MAMBAF722.config
@@ -104,7 +104,7 @@ resource ESCSERIAL 1 B09
 resource PINIO 1 B00
 
 # feature
-feature RX_SERIAL
+#feature RX_SERIAL
 feature TELEMETRY
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/MATEKF405MINI.config
+++ b/configs/default/MATEKF405MINI.config
@@ -104,7 +104,7 @@ dma pin A01 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/MATEKF411.config
+++ b/configs/default/MATEKF411.config
@@ -78,7 +78,7 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MATEKF722MINI.config
+++ b/configs/default/MATEKF722MINI.config
@@ -111,7 +111,7 @@ dma pin A00 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/OMNIBUSF4FW.config
+++ b/configs/default/OMNIBUSF4FW.config
@@ -102,7 +102,7 @@ dma pin A01 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/OMNIBUSF4NANOV7.config
+++ b/configs/default/OMNIBUSF4NANOV7.config
@@ -71,7 +71,7 @@ dma pin B07 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/OMNIBUSF4SD.config
+++ b/configs/default/OMNIBUSF4SD.config
@@ -117,7 +117,7 @@ dma pin A10 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/OMNIBUSF4V6.config
+++ b/configs/default/OMNIBUSF4V6.config
@@ -102,7 +102,7 @@ dma pin A01 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/OMNIBUSF7NANOV7.config
+++ b/configs/default/OMNIBUSF7NANOV7.config
@@ -70,7 +70,7 @@ dma pin B07 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/SPEEDYBEEF7.config
+++ b/configs/default/SPEEDYBEEF7.config
@@ -98,7 +98,7 @@ dma pin B00 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD
 

--- a/configs/default/TALONF7FUSION.config
+++ b/configs/default/TALONF7FUSION.config
@@ -72,7 +72,7 @@ dma pin B01 0               # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/TALONF7V2.config
+++ b/configs/default/TALONF7V2.config
@@ -70,7 +70,7 @@ dma pin B01 0           # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/TRANSTECF7.config
+++ b/configs/default/TRANSTECF7.config
@@ -82,7 +82,7 @@ dma pin A15 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature OSD
 
 # serial

--- a/configs/default/XILOF4.config
+++ b/configs/default/XILOF4.config
@@ -73,7 +73,7 @@ dma pin B07 0
 
 # feature
 feature -RX_PARALLEL_PWM
-feature RX_SERIAL
+#feature RX_SERIAL
 feature ESC_SENSOR
 feature OSD
 


### PR DESCRIPTION
Mitigation for the bug in betaflight/betaflight#8919 - we'll re-enable the RX_SERIAL feature once this has been fixed.