### PR TITLE
add a file index, and another check, powered by node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,15 @@ dist: bionic
 git:
   depth: 5
 
+language: node_js
+
+node_js:
+  - 10
+
 script:
   - make test
+  - node verify-targets.js
+  - ./verify-json.sh
 
 # Notifications are encrypted to betaflight/unified-targets to avoid spam from forks
 # Command: `travis encrypt "<secret>" -r betaflight/unified-targets --com`

--- a/target-configs.json
+++ b/target-configs.json
@@ -1,0 +1,352 @@
+{
+  "default": [
+    {
+      "filename": "AFNG-ALIENFLIGHTF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AFNG-ALIENFLIGHTNGF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AFNG-ALIENFLIGHTNGF7_DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AFNG-ALIENFLIGHTNGF7_SPIRX.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AIKO-AIKONF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIKO-AIKONF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AIRB-AIRBOTF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-AIRBOTF4SD.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-AIRBOTF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AIRB-LUXMINIF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF4FW.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF4NANOV7.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF4SD.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF4V6.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF7NANOV7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "AIRB-OMNIBUSF7V2.config",
+      "bareboard": "STM32F745"
+    },
+    {
+      "filename": "AIRB-OMNINXT4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "AIRB-XILOF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "BKMN-NERO.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "CLRA-CLRACINGF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "CLRA-CLRACINGF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "CUST-SIRMIXALOT.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "DALR-DALRCF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "DALR-DALRCF722DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "DIAT-FURYF4OSD.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "DIAT-MAMBAF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "DIAT-MAMBAF722.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "DRCL-ELINF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "DRCL-ELINF722.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "DYST-DYSF4PRO.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "EXUA-EXF722DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "FFPV-FF_RACEPIT.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "FFPV-FF_RACEPIT_MINI.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "FLWO-FLYWOOF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "FLWO-FLYWOOF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "FLWO-FLYWOOF7DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "FOXE-FOXEERF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "FOXE-FOXEERF722DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "FPVM-FPVM_BETAFLIGHTF7.config",
+      "bareboard": "STM32F745"
+    },
+    {
+      "filename": "HAMO-CRAZYBEEF4FR.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "HARC-HAKRCF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "HARC-HAKRCF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "HBRO-KAKUTEF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "HBRO-KAKUTEF4V2.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "HBRO-KAKUTEF7.config",
+      "bareboard": "STM32F745"
+    },
+    {
+      "filename": "HBRO-KAKUTEF7MINI.config",
+      "bareboard": "STM32F745"
+    },
+    {
+      "filename": "HENA-TALONF7FUSION.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "HENA-TALONF7V2.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "HGLR-HGLRCF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "HGLR-HGLRCF405AS.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "HGLR-HGLRCF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "HGLR-HGLRCF745.config",
+      "bareboard": "STM32F745"
+    },
+    {
+      "filename": "IFRC-IFF411_PRO.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "IFRC-IFF411_TWING.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "IFRC-IFF4_TWIN_G.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "IFRC-IFF7_TWIN_G.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "JHEF-JHEF7DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "KLEE-SYNERGYF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MERA-MERAKRCF405.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MERA-MERAKRCF722.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "MOLA-MLTEMPF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MOLA-MLTYPHF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MTKS-MATEKF405CTR.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MTKS-MATEKF405MINI.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MTKS-MATEKF405STD.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "MTKS-MATEKF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "MTKS-MATEKF411RX.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "MTKS-MATEKF411SE.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "MTKS-MATEKF722.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "MTKS-MATEKF722MINI.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "MTKS-MATEKF722SE.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "OPEN-REVO.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "RAST-AIRF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "RCTI-BEEROTORF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "RUSH-RUSHCORE7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "SPBE-SPEEDYBEEF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "SPBE-SPEEDYBEEF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "SPDX-SPEDIXF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "SPRO-SPRACINGF7DUAL.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "TACO-MODULARF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "TMTR-TMOTORF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "TMTR-TMOTORF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "TTRH-TRANSTECF411.config",
+      "bareboard": "STM32F411"
+    },
+    {
+      "filename": "TTRH-TRANSTECF7.config",
+      "bareboard": "STM32F7X2"
+    },
+    {
+      "filename": "VGRC-VGOODRCF4.config",
+      "bareboard": "STM32F405"
+    },
+    {
+      "filename": "VIVA-VIVAF4AIO.config",
+      "bareboard": "STM32F405"
+    }
+  ]
+}

--- a/verify-json.sh
+++ b/verify-json.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script is for Continuous Integration, it triggers a complaint
+# if ANY files are changed in the repo by earlier steps, so is not intended to be ran by devs
+
+if ! git diff --quiet HEAD --; then
+    git status
+    echo
+    echo Has a new target been added? please update target-configs.json
+    exit 1
+fi

--- a/verify-targets.js
+++ b/verify-targets.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function grabBuildNameFromConfig(config) {
+    let bareBoard;
+    try {
+        let firstLineItems = config.split("\n")[0].split(' ');
+        if (!(firstLineItems[0] == '#' && firstLineItems[1] == 'Betaflight' && firstLineItems[2] == '/')) {
+            throw new Error('Could not find header');
+            return undefined;
+        }
+        bareBoard = firstLineItems[3];
+    } catch (e) {
+        bareBoard = undefined;
+        console.log('grabBuildNameFromConfig failed: ', e.message);
+    }
+    return bareBoard;
+}
+
+function cleanUnifiedConfigFile(input) {
+    let output = [];
+    let inComment = false;
+    for (let i=0; i < input.length; i++) {
+        if (input.charAt(i) == "\n" || input.charAt(i) == "\r") {
+            inComment = false;
+        }
+        if (input.charAt(i) == "#") {
+            inComment = true;
+        }
+        if (!inComment && input.charCodeAt(i) > 255) {
+            // Note: we're not showing this error in betaflight-configurator
+            throw new Error('commands are limited to characters 0-255, comments have no limitation');
+        }
+        if (input.charCodeAt(i) > 255) {
+            output.push('_');
+        } else {
+            output.push(input.charAt(i));
+        }
+    }
+    return output.join('');
+}
+
+function testUnifiedConfigFile(filePath) {
+    let config;
+    let configCleaned;
+    config = fs.readFileSync(filePath, 'UTF-8');
+    configCleaned = cleanUnifiedConfigFile(config);
+    return grabBuildNameFromConfig(config);
+}
+
+function walkSync(currentDirPath, callback) {
+    fs.readdirSync(currentDirPath).forEach(function (name) {
+        var filePath = path.join(currentDirPath, name);
+        var stat = fs.statSync(filePath);
+        if (stat.isFile()) {
+            callback(filePath, stat);
+        } else if (stat.isDirectory()) {
+            walkSync(filePath, callback);
+        }
+    });
+}
+
+let configs = {};
+let problems = false; // Start with no problems
+
+walkSync('configs', function (filePath, stat) {
+    let bareBoard;
+    try {
+        bareBoard = testUnifiedConfigFile(filePath);
+        if (bareBoard === undefined) {
+            throw new Error ('Unspecified firmware')
+        }
+    } catch (err) {
+        //console.error(err);
+        console.log(filePath, err.toString());
+        problems = true;
+    }
+    var pathParts = filePath.split('/');
+    if (configs[pathParts[1]] === undefined) {
+        configs[pathParts[1]] = [];
+    }
+    //configs[pathParts[1]].push(pathParts[2]);
+    configs[pathParts[1]].push({ filename: pathParts[2], bareboard: bareBoard});
+    //console.log(filePath, pathParts[2], bareBoard);
+});
+if (!problems) {
+    fs.writeFileSync('target-configs.json', JSON.stringify(configs, null, 2).concat("\n"));
+} else {
+    console.log('One or more problems occured, see above');
+    process.exitCode = 1;
+}


### PR DESCRIPTION
I've deleted KAKUTEF4V2 from the `target-configs.json`, so this should fail. Hopefully.

the `verify-targets.js` should write out a fresh `target-configs.json`, and `verify-json.sh` will notice there has been changes.