### PR TITLE
Fixed bluetooth on SPEEDYBEEF4.

### DIFF
--- a/configs/default/SPBE-SPEEDYBEEF4.config
+++ b/configs/default/SPBE-SPEEDYBEEF4.config
@@ -92,6 +92,9 @@ dma pin B06 0
 # feature
 feature OSD
 
+# serial
+serial 4 1 19200 57600 0 115200
+
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1
@@ -107,6 +110,8 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set dashboard_i2c_bus = 1
+set pinio_config = 129,1,1,1
+set pinio_box = 0,255,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1


### PR DESCRIPTION
Fixes betaflight/betaflight#9006.

These are needed to power the on-board bluetooth chipset when disarmed and configure the UART it is connected to.