### PR TITLE
Add Airbot OMNINXT4 unified config file

### DIFF
--- a/configs/default/AIRB-OMNINXT4.config
+++ b/configs/default/AIRB-OMNINXT4.config
@@ -1,0 +1,159 @@
+# Betaflight / STM32F405 (S405) 4.1.0 Oct 16 2019 / 11:57:16 (c37a7c91a) MSP API: 1.42
+# manufacturer_id: AIRB   board_name: OMNINXT4   custom defaults: NO
+
+board_name OMNINXT4
+manufacturer_id AIRB
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B05
+resource MOTOR 2 B04
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+resource PPM 1 B07
+resource LED_STRIP 1 A09
+resource SERIAL_TX 1 B06
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 B07
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource INVERTER 2 C05
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B02
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 C03
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 B07
+resource CAMERA_CONTROL 1 B15
+resource ADC_BATT 1 C00
+resource ADC_RSSI 1 C04
+resource ADC_CURR 1 C01
+resource ADC_EXT 1 A04
+resource BARO_CS 1 A10
+resource FLASH_CS 1 C14
+resource OSD_CS 1 A15
+resource GYRO_CS 1 B12
+resource GYRO_CS 2 A08
+
+# timer
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer B15 AF9
+# pin B15: TIM12 CH2 (AF9)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A09 0
+# pin A09: DMA2 Stream 6 Channel 0
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin B11 0
+# pin B11: DMA1 Stream 7 Channel 3
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 4 1024 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_spi_device = 2
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW270
+set gyro_2_align_yaw = 2700


### PR DESCRIPTION
Adds Airbot OMNINXT4 unified target. 

I think this target is not commercially available, but I had a sample and created it as stated here: https://github.com/betaflight/betaflight/issues/9044