### PR TITLE
HENA - Move power switch to be controlled by USER1 (40) instead of Pit mode (39)

### DIFF
--- a/configs/default/HENA-TALONF7FUSION.config
+++ b/configs/default/HENA-TALONF7FUSION.config
@@ -80,7 +80,7 @@ serial 0 2048 115200 57600 0 115200
 serial 2 64 115200 57600 0 115200
 
 # aux
-aux 0 39 0 900 2100 0 0
+aux 0 40 0 900 2100 0 0
 
 # master
 set gyro_to_use = BOTH
@@ -114,4 +114,4 @@ set osd_current_pos = 2439
 set osd_mah_drawn_pos = 2433
 set osd_craft_name_pos = 2058
 set osd_warnings_pos = 14378
-set pinio_box = 39,255,255,255
+set pinio_box = 40,255,255,255

--- a/configs/default/HENA-TALONF7V2.config
+++ b/configs/default/HENA-TALONF7V2.config
@@ -79,7 +79,7 @@ serial 2 64 115200 57600 0 115200
 
 
 # aux
-aux 0 39 0 900 2100 0 0
+aux 0 40 0 900 2100 0 0
 
 # master
 set mag_hardware = NONE
@@ -109,4 +109,4 @@ set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
-set pinio_box = 39,255,255,255
+set pinio_box = 40,255,255,255


### PR DESCRIPTION
This change will require a change in documentation. 

Assigning VTX Power switch to USER1 instead of VTX Pit mode allows the use of both modes without confusion.