### PR TITLE
Fix OMNIBUSF4FW current sensor offset and default UART settings

### DIFF
--- a/configs/default/AIRB-OMNIBUSF4FW.config
+++ b/configs/default/AIRB-OMNIBUSF4FW.config
@@ -106,7 +106,8 @@ feature RX_SERIAL
 feature OSD
 
 # serial
-serial 5 64 115200 57600 0 115200
+serial 0 64 115200 57600 0 115200
+serial 3 1024 115200 57600 0 115200
 
 # master
 set mag_bustype = I2C
@@ -117,7 +118,7 @@ set blackbox_device = SPIFLASH
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 176
-set ibata_offset = -1850
+set ibata_offset = -18500
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8


### PR DESCRIPTION
Current sensor offset was incorrect by an order of 10. Default UART settings were based on OMNIBUSF4V6 instead of OMNIBUSF4FW.