### PR TITLE
Add HIFIONRCF7 Unified Targets

### DIFF
--- a/configs/default/HFOR-HIFIONRCF7.config
+++ b/configs/default/HFOR-HIFIONRCF7.config
@@ -1,0 +1,115 @@
+# Betaflight / STM32F7X2 (S7X2) 4.0.0 Apr  1 2019 / 16:45:55 (f0ac671fa) MSP API: 1.41
+
+board_name HIFIONRCF7
+manufacturer_id HFOR
+
+# resources
+resource BEEPER 1 C15
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 B04
+resource MOTOR 4 B03
+resource MOTOR 5 C09
+resource MOTOR 6 C08
+resource PPM 1 A03
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 A15
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource CAMERA_CONTROL 1 B08
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C01
+resource PINIO 1 C14
+resource PINIO 2 B09
+resource FLASH_CS 1 C13
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 C03
+resource GYRO_CS 1 B02
+resource GYRO_CS 2 A04
+
+# timer
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+
+# dma
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+
+# feature
+feature OSD
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set adc_device = 3
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 450
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set pinio_box = 40,41,255,255
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW90
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW90


### PR DESCRIPTION
According to the betaflight community rule, need to add the manufacturer id before merge this pr. 
https://github.com/betaflight/unified-targets/issues/81