### PR TITLE
Motors 5 and 6 resource added

### DIFF
--- a/configs/default/AIRB-OMNIBUSF4V6.config
+++ b/configs/default/AIRB-OMNIBUSF4V6.config
@@ -9,6 +9,8 @@ resource MOTOR 1 B00
 resource MOTOR 2 B01
 resource MOTOR 3 A03
 resource MOTOR 4 B05
+resource MOTOR 5 C08
+resource MOTOR 6 C09
 resource PPM 1 B08
 resource LED_STRIP 1 B06
 resource SERIAL_TX 1 A09


### PR DESCRIPTION
Resources for motors 5 and 6 are missing, added for OmnibusF4 V6