### PR TITLE
Switch F411 targets with timer1 conflicts to use timer dshot

### DIFF
--- a/configs/default/DIAT-MAMBAF411.config
+++ b/configs/default/DIAT-MAMBAF411.config
@@ -89,4 +89,5 @@ set mag_hardware = NONE
 set baro_hardware = NONE
 set serialrx_provider = SBUS
 set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set motor_pwm_protocol = DSHOT600

--- a/configs/default/HAMO-CRAZYBEEF4DX.config
+++ b/configs/default/HAMO-CRAZYBEEF4DX.config
@@ -84,6 +84,8 @@ map TAER1234
 serial 1 64 115200 57600 0 115200
 
 # master
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set serialrx_provider = SPEK2048
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC

--- a/configs/default/HAMO-CRAZYBEEF4FR.config
+++ b/configs/default/HAMO-CRAZYBEEF4FR.config
@@ -81,6 +81,8 @@ feature OSD
 feature RX_SPI
 
 # master
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set rx_spi_protocol = FRSKY_X
 set rx_spi_bus = 3
 set motor_pwm_protocol = DSHOT600

--- a/configs/default/HAMO-CRAZYBEEF4FS.config
+++ b/configs/default/HAMO-CRAZYBEEF4FS.config
@@ -81,6 +81,8 @@ feature OSD
 feature RX_SPI
 
 # master
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set rx_spi_protocol = FLYSKY_2A
 set rx_spi_bus = 3
 set motor_pwm_protocol = DSHOT600

--- a/configs/default/MTKS-MATEKF411.config
+++ b/configs/default/MTKS-MATEKF411.config
@@ -93,6 +93,7 @@ serial 0 64 115200 57600 0 115200
 # master
 set serialrx_provider = SBUS
 set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1


### PR DESCRIPTION
This fix switches F411 targets with timer 1 conflicts using bitbang dshot to timer dshot to bring these configs in sync with the legacy targets.