### PR TITLE
Add IFRC-IFF7_TWIN_G_D

### DIFF
--- a/configs/default/IFRC-IFF7_TWIN_G_D.config
+++ b/configs/default/IFRC-IFF7_TWIN_G_D.config
@@ -1,0 +1,136 @@
+# Betaflight / STM32F7X2 (S7X2) 4.0.3 Jun  1 2019 / 11:59:57 (094cfc956) MSP API: 1.41
+
+board_name IFF7_TWIN_G_D
+manufacturer_id IFRC
+
+# resources
+resource BEEPER 1 C15
+resource MOTOR 1 C08
+resource MOTOR 2 C06
+resource MOTOR 3 C09
+resource MOTOR 4 C07
+resource MOTOR 5 B06
+resource MOTOR 6 B07
+resource MOTOR 7 B01
+resource MOTOR 8 B00
+resource PPM 1 A03
+resource LED_STRIP 1 A01
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 C10
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 C11
+resource SERIAL_RX 5 D02
+resource I2C_SCL 2 B10
+resource I2C_SDA 2 B11
+resource LED 1 C04
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource CAMERA_CONTROL 1 A00
+resource ADC_BATT 1 C01
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C02
+resource PINIO 1 C13
+resource PINIO 2 C14
+resource PINIO 3 B08
+resource FLASH_CS 1 B09
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 A08
+resource GYRO_EXTI 2 B02
+resource GYRO_CS 1 A15
+resource GYRO_CS 2 C03
+
+# timer
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer A01 AF1
+# pin A01: TIM2 CH2 (AF1)
+
+# dma
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin A01 0
+# pin A01: DMA1 Stream 6 Channel 3
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature SOFTSERIAL
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set gyro_to_use = BOTH
+set baro_bustype = I2C
+set baro_i2c_device = 2
+set mag_bustype = I2C
+set mag_i2c_device = 2
+set serialrx_provider = SBUS
+set adc_device = 3
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 100
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 2
+set pinio_config = 129,1,1,1
+set pinio_box = 0,255,255,255
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = DEFAULT


### PR DESCRIPTION
Add iflight SucceX-D Mini F7

Adds support for the [iFlight SucceX-D Mini F7 board](https://www.iflight-rc.com/index.php?route=product/product&path=86_87&product_id=1060) which has different gyro alignment than the non-D board.

Fixes #98

@Linjieqiang here is my proposal to fix the issue with different hardware. Would you please confirm that this is different hardware?