### PR TITLE
Fix gyro detection on specific targets

### DIFF
--- a/configs/default/AIRB-AIRBOTF7.config
+++ b/configs/default/AIRB-AIRBOTF7.config
@@ -88,4 +88,6 @@ set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW90
 set gyro_1_align_yaw = 900
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
+

--- a/configs/default/AIRB-AIRBOTF7.config
+++ b/configs/default/AIRB-AIRBOTF7.config
@@ -90,4 +90,3 @@ set gyro_1_sensor_align = CW90
 set gyro_1_align_yaw = 900
 set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
-

--- a/configs/default/AIRB-OMNIBUSF4FW.config
+++ b/configs/default/AIRB-OMNIBUSF4FW.config
@@ -127,5 +127,6 @@ set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW180
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
 set gyro_2_sensor_align = CW0FLIP

--- a/configs/default/AIRB-OMNIBUSF4NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF4NANOV7.config
@@ -94,5 +94,6 @@ set flash_spi_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW0
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
 set gyro_2_sensor_align = CW0

--- a/configs/default/AIRB-OMNIBUSF4V6.config
+++ b/configs/default/AIRB-OMNIBUSF4V6.config
@@ -125,5 +125,6 @@ set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
 set gyro_2_sensor_align = CW0

--- a/configs/default/AIRB-OMNIBUSF7NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF7NANOV7.config
@@ -93,4 +93,5 @@ set flash_spi_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW0
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 3

--- a/configs/default/RAST-AIRF7.config
+++ b/configs/default/RAST-AIRF7.config
@@ -88,5 +88,6 @@ set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW90
+set gyro_2_bustype = NONE
 set gyro_2_spibus = 1
 set gyro_2_sensor_align = CW0


### PR DESCRIPTION
Since gyro detection for Dualgyro setups is improved, Dual gyro boards with only one gyro connected have been affected. When it is going to initialize configured by default in ```gyroauto```, it searches for gyroscopes in the spi port of gyro 2, since it does not have gyro installed, the search for this is delayed and a very long initialization is generated. I have disabled this search for these target. Also @airbotfpv should include in its manuals how to activate Gyro 2 for those who want it.
This fix #9144 https://github.com/betaflight/betaflight/issues/9144