### PR TITLE
Add missing -RX_PARALLEL_PWM

### DIFF
--- a/configs/default/HAMO-CRAZYBEEF4FS.config
+++ b/configs/default/HAMO-CRAZYBEEF4FS.config
@@ -79,6 +79,7 @@ dma pin A10 0
 # feature
 feature OSD
 feature RX_SPI
+feature -RX_PARALLEL_PWM
 
 # master
 set dshot_burst = AUTO


### PR DESCRIPTION
Added missing ```-RX_PARALLEL_PWM``` to CrazybeeF4FS config