### PR TITLE
Added new manufacturer Manaz GCS and target maintainer.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,7 @@
 /configs/default/IFRC-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/LMNR-* @x4FF3 @betaflight/unified-target-administrators
 /configs/default/MTKS-* @MATEKSYS @betaflight/unified-target-administrators
+/configs/default/MZGC-* @JanikProphet @betaflight/unified-target-administrators
 /configs/default/RCTI-* @mikeller-test @betaflight/unified-target-administrators
 /configs/default/RUSH-* @nyway @betaflight/unified-target-administrators
 /configs/default/SPDX-* @DieHertz @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -34,6 +34,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |MERA|MerakRC|http://www.merakrc.com/|
 |MOLA|MotoLab|https://github.com/MotoLab|
 |MTKS|Matek Systems|http://www.mateksys.com/|
+|MZGC|Manaz GCS|https://www.shop-mzgcs.de/|
 |OPEN|OpenPilot|https://librepilot.atlassian.net/wiki/display/LPDOC/OpenPilot+Revolution|
 |RAST|Racerstar|https://www.racerstar.com/|
 |RCTI|RCTimer|http://rctimer.com/|


### PR DESCRIPTION
Fixes betaflight/betaflight#9171.

@JanikProphet: I have also added you as the target maintainer for Manaz' targets. Please let me know if this is incorrect.