### PR TITLE
Added manufacturer id and maintainer for Pyrodrone.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,6 +60,7 @@
 /configs/default/MTKS-* @MATEKSYS @betaflight/unified-target-administrators
 /configs/default/MZGC-* @JanikProphet @betaflight/unified-target-administrators
 /configs/default/NEBD-* @yangyeah @betaflight/unified-target-administrators
+/configs/default/PYDR-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/RCTI-* @mikeller-test @betaflight/unified-target-administrators
 /configs/default/RUSH-* @nyway @betaflight/unified-target-administrators
 /configs/default/SPDX-* @DieHertz @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -37,6 +37,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |MZGC|Manaz GCS|https://www.shop-mzgcs.de/|
 |NEBD|NewBeeDrone|https://newbeedrone.com/|
 |OPEN|OpenPilot|https://librepilot.atlassian.net/wiki/display/LPDOC/OpenPilot+Revolution|
+|PYDR|Pyro-Drone|https://pyrodrone.com/|
 |RAST|Racerstar|https://www.racerstar.com/|
 |RCTI|RCTimer|http://rctimer.com/|
 |RUSH|FPV Racing Rush|http://www.rushfpv.com/|


### PR DESCRIPTION
Fixes betaflight/betaflight#9196.