### PR TITLE
set the default current scale for holybro F4/F7 FC

### DIFF
--- a/configs/default/HBRO-KAKUTEF4.config
+++ b/configs/default/HBRO-KAKUTEF4.config
@@ -89,6 +89,7 @@ serial 2 64 115200 57600 0 115200
 # master
 set serialrx_provider = SBUS
 set battery_meter = ADC
+set ibata_scale = 275
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8

--- a/configs/default/HBRO-KAKUTEF4V2.config
+++ b/configs/default/HBRO-KAKUTEF4V2.config
@@ -89,6 +89,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 1
 set serialrx_provider = SBUS
 set battery_meter = ADC
+set ibata_scale = 275
 set beeper_inversion = ON
 set beeper_od = OFF
 set tlm_inverted = ON

--- a/configs/default/HBRO-KAKUTEF7.config
+++ b/configs/default/HBRO-KAKUTEF7.config
@@ -96,6 +96,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SDCARD
 set current_meter = ADC
+set ibata_scale = 275
 set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF

--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -78,7 +78,19 @@ dma pin A03 0
 dma pin D12 0
 # pin D12: DMA1 Stream 0 Channel 2
 
+# serial
+serial 0 1 115200 57600 0 115200
+serial 5 64 115200 57600 0 115200
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
 # master
+set serialrx_provider = SBUS
+set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set baro_bustype = I2C

--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -85,6 +85,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SDCARD
 set current_meter = ADC
+set ibata_scale = 275
 set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF

--- a/configs/default/HBRO-KAKUTEF7MINI.config
+++ b/configs/default/HBRO-KAKUTEF7MINI.config
@@ -93,6 +93,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
 set current_meter = ADC
+set ibata_scale = 275
 set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF


### PR DESCRIPTION
The current meter scale of holybro F4/F7 FC or ESC is 275. Set it to default, because it's difficult for a user to calibrate without a dedicated device.