### PR TITLE
Add IFF4_AIO none OSD version Config

### DIFF
--- a/configs/default/IFRC-IFF4_AIO_OSD.config
+++ b/configs/default/IFRC-IFF4_AIO_OSD.config
@@ -1,6 +1,6 @@
 # Betaflight / STM32F405 (S405) 4.0.0 Mar 14 2019 / 11:45:26 (360afd96d) MSP API: 1.41
 
-board_name IFF4_AIO 
+board_name IFF4_AIO_OSD 
 manufacturer_id IFRC
 
 # resources
@@ -38,6 +38,7 @@ resource ADC_CURR 1 C01
 resource PINIO 1 C15
 resource PINIO 2 C14
 resource FLASH_CS 1 A15
+resource OSD_CS 1 B12
 resource GYRO_EXTI 1 C04
 resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
@@ -80,6 +81,7 @@ feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP
 feature DISPLAY
+feature OSD
 
 # serial
 serial 1 64 115200 57600 0 115200
@@ -94,6 +96,7 @@ set battery_meter = ADC
 set ibata_scale = 100
 set pid_process_denom = 1
 set system_hse_mhz = 8
+set max7456_spi_bus = 2
 set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3


### PR DESCRIPTION
According to user feedback, we made two versions of the fc hardware board, one with OSD and one without OSD. 

However, we found that the firmware did not enable the automatic detection of the OSD chip, which resulted in the inability to perform flight unlocking without OSD.

The video is here: https://www.youtube.com/watch?v=_EEoW1pXgVU&feature=youtu.be 

So we need two separate configuration files.