### PR TITLE
Merge pull request #160 from betaflight/mtks-f411-add-missing-i2c-resources

### DIFF
--- a/configs/default/MTKS-MATEKF411.config
+++ b/configs/default/MTKS-MATEKF411.config
@@ -17,6 +17,8 @@ resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
 resource LED 1 C13
 resource LED 2 C14
 resource SPI_SCK 1 A05


### PR DESCRIPTION
- https://github.com/betaflight/betaflight/blob/master/src/main/target/MATEKF411/target.h#L65-L66
- https://www.facebook.com/groups/betaflightgroup/permalink/456835145012367/?comment_id=456862831676265