### PR TITLE
Fixing timer settings on Kakute F7 HDV defaults

### DIFF
--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -47,14 +47,22 @@ resource GYRO_CS 1 E04
 resource USB_DETECT 1 A08
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer C09 1
-timer A03 1
-timer D12 0
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
 
 # dma
 dma SPI_TX 1 1

--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -112,7 +112,6 @@ set beeper_od = OFF
 set sdcard_detect_inverted = ON
 set sdcard_mode = SPI
 set sdcard_spi_bus = 1
-set system_hse_mhz = 8
 set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 4


### PR DESCRIPTION
Fixing timer settings on Kakute F7 HDV defaults to match the original Kakute F7, as the current ones don't get applied and stop the esc working in BF 4.2. I'm unsure how to verify these are correct, but applying them got my ESC to boot correctly and motors etc work fine now. Betaflight-configurator should probably warn the user when 'apply custom defaults' has errors too.