### PR TITLE
fix KakuteF7HDV timer config and I2C error

### DIFF
--- a/configs/default/HBRO-KAKUTEF7.config
+++ b/configs/default/HBRO-KAKUTEF7.config
@@ -92,8 +92,10 @@ feature OSD
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1
+set mag_hardware = NONE
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set baro_hardware = BMP280
 set blackbox_device = SDCARD
 set current_meter = ADC
 set ibata_scale = 275

--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -47,14 +47,22 @@ resource GYRO_CS 1 E04
 resource USB_DETECT 1 A08
 
 # timer
-timer E13 0
-timer B00 1
-timer B01 1
-timer E09 0
-timer E11 0
-timer C09 1
-timer A03 1
-timer D12 0
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
 
 # dma
 dma SPI_TX 1 1
@@ -93,8 +101,10 @@ set serialrx_provider = SBUS
 set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
+set mag_hardware = NONE
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set baro_hardware = BMP280
 set blackbox_device = SDCARD
 set current_meter = ADC
 set ibata_scale = 275
@@ -104,7 +114,6 @@ set beeper_od = OFF
 set sdcard_detect_inverted = ON
 set sdcard_mode = SPI
 set sdcard_spi_bus = 1
-set system_hse_mhz = 8
 set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 4

--- a/configs/default/HBRO-KAKUTEF7MINI.config
+++ b/configs/default/HBRO-KAKUTEF7MINI.config
@@ -89,8 +89,10 @@ feature OSD
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1
+set mag_hardware = NONE
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set baro_hardware = BMP280
 set blackbox_device = SPIFLASH
 set current_meter = ADC
 set ibata_scale = 275


### PR DESCRIPTION
1,Except for the Max7456 osd section, the pin definition of kakutef7hdv is  the same as that of kakutef7. So the timer definition should be exactly the same.

2, we can connect a external mag on I2C bus, but there is no a mag onboard. Set "mag_hardware = NONE" to  eliminate I2C error report on Betaflight configurator.

3, BMP280 baro is used onboard. Set "baro_hardware = BMP280" to  eliminate I2C error report on Betaflight configurator.