### PR TITLE
add new target DRONIUSF7

### DIFF
--- a/configs/default/FOSS-DRONIUSF7.config
+++ b/configs/default/FOSS-DRONIUSF7.config
@@ -1,4 +1,3 @@
-# version
 # Betaflight / DRONIUSF7 (FOSS) 4.1.5 Mar  9 2020 / 16:02:05 (7a5ffad37) MSP API: 1.42
 
 board_name DRONIUSF7

--- a/configs/default/FOSS-DRONIUSF7.config
+++ b/configs/default/FOSS-DRONIUSF7.config
@@ -1,9 +1,9 @@
-# Betaflight / DRONIUSF7 (FOSS) 4.1.5 Mar  9 2020 / 16:02:05 (7a5ffad37) MSP API: 1.42
+# Betaflight / STM32F7X2 (S7X2) 4.1.5 Mar 16 2020 / 05:21:46 (d4e74e39c) MSP API: 1.42
 
 board_name DRONIUSF7
 manufacturer_id FOSS
 
-# resource
+# resources
 resource BEEPER 1 C13
 resource MOTOR 1 A09
 resource MOTOR 2 A08
@@ -59,8 +59,8 @@ timer A15 AF1
 # pin A15: TIM2 CH1 (AF1)
 
 # dma
-dma ADC 3 0
-# ADC 3: DMA2 Stream 0 Channel 2
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
 dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 dma pin A09 0
@@ -75,4 +75,34 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-Enabled: RX_SERIAL TELEMETRY OSD AIRMODE ANTI_GRAVITY DYNAMIC_FILTER 
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 2 2048 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set mag_hardware = NONE
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_i2c_address = 119
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0FLIP
+set gyro_1_align_pitch = 1800

--- a/configs/default/FOSS-DRONIUSF7.config
+++ b/configs/default/FOSS-DRONIUSF7.config
@@ -1,0 +1,79 @@
+# version
+# Betaflight / DRONIUSF7 (FOSS) 4.1.5 Mar  9 2020 / 16:02:05 (7a5ffad37) MSP API: 1.42
+
+board_name DRONIUSF7
+manufacturer_id FOSS
+
+# resource
+resource BEEPER 1 C13
+resource MOTOR 1 A09
+resource MOTOR 2 A08
+resource MOTOR 3 C08
+resource MOTOR 4 C09
+resource PPM 1 B07
+resource LED_STRIP 1 A15
+resource SERIAL_TX 1 B06
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 B07
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ADC_BATT 1 C01
+resource ADC_CURR 1 C00
+resource PINIO 1 C02
+resource FLASH_CS 1 B02
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 B10
+resource GYRO_CS 1 B00
+resource USB_DETECT 1 A10
+
+# timer
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+
+# dma
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A09 0
+# pin A09: DMA2 Stream 6 Channel 0
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+
+# feature
+Enabled: RX_SERIAL TELEMETRY OSD AIRMODE ANTI_GRAVITY DYNAMIC_FILTER 


### PR DESCRIPTION
add new target DRONIUSF7

STM32F722RE, 6x UART, OSD (AT7456E) MPU6000, BMP280, 2x BEC 3A (6S - SY8303 chip DC/DC), VTX power control

full config (target.h, target.c, target.mk)
https://github.com/cvetaevvitaliy/DRONIUSF7

<img width="676" alt="1" src="https://user-images.githubusercontent.com/26421560/76238004-d2f1b280-6237-11ea-8ddd-957bad82050f.png">
<img width="707" alt="2" src="https://user-images.githubusercontent.com/26421560/76238017-d71dd000-6237-11ea-9866-a66d84475196.png">

[DRONIUSF7_V1.0.PDF](https://github.com/betaflight/unified-targets/files/4312486/DRONIUSF7_V1.0.PDF)
