### PR TITLE
Fixed I2C pin definitions for IFF4_TWIN_G.

### DIFF
--- a/configs/default/IFRC-IFF4_TWIN_G.config
+++ b/configs/default/IFRC-IFF4_TWIN_G.config
@@ -23,8 +23,8 @@ resource SERIAL_RX 3 B11
 resource SERIAL_RX 6 C07
 resource SERIAL_RX 11 B08
 resource INVERTER 2 C13
-resource I2C_SCL 1 B10
-resource I2C_SDA 1 B11
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
 resource LED 1 B05
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13


### PR DESCRIPTION
Fixes betaflight/betaflight#9604.