### PR TITLE
Disabling the VTX switch on TALONF7V2 due to thermal problems caused by it.

### DIFF
--- a/configs/default/HENA-TALONF7V2.config
+++ b/configs/default/HENA-TALONF7V2.config
@@ -40,7 +40,9 @@ resource CAMERA_CONTROL 1 B03
 resource ADC_BATT 1 C02
 resource ADC_RSSI 1 C03
 resource ADC_CURR 1 C01
-resource PINIO 1 A14
+# Disabling the VTX switch due to thermal problems reported in
+# https://github.com/betaflight/betaflight/issues/9516
+#resource PINIO 1 A14
 resource FLASH_CS 1 B12
 resource OSD_CS 1 A15
 resource GYRO_EXTI 1 C04
@@ -109,4 +111,4 @@ set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
-set pinio_box = 40,255,255,255
+#set pinio_box = 40,255,255,255


### PR DESCRIPTION
Fixes betaflight/betaflight#9516.

@bnn1044: I think this needs some more investigation, but it looks like the hardware is defective.