### PR TITLE
SKST-SKYSTARSF411.config

### DIFF
--- a/configs/default/SKST-SKYSTARSF411.config
+++ b/configs/default/SKST-SKYSTARSF411.config
@@ -1,0 +1,129 @@
+# Betaflight / STM32F411 (S411) 4.1.0 Jun 25 2019 / 10:27:57 (2a6e94d03) MSP API: 1.42
+
+board_name SKYSTARSF411
+manufacturer_id SKST
+
+# resources
+resource LED 1 C13
+resource PPM 1 A03
+resource BEEPER 1 B02
+resource LED_STRIP 1 A08
+
+# Motor
+resource MOTOR 1 A00
+resource MOTOR 2 A01
+resource MOTOR 3 B06
+resource MOTOR 4 B07
+resource MOTOR 5 B10
+resource MOTOR 6 NONE
+
+# UART1
+resource SERIAL_TX 1 A09
+resource SERIAL_RX 1 A10
+
+# UART2
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 2 A03
+
+# SOFTSERIAL1
+resource SERIAL_TX 11 B00
+resource SERIAL_RX 11 B00
+
+# IIC1
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+
+#GYRO & ACC --> SPI1
+resource GYRO_CS 1 C15
+resource SPI_SCK 1 A05
+resource SPI_MISO 1 A06
+resource SPI_MOSI 1 A07
+resource GYRO_EXTI 1 C14
+
+# OSD --> SPI2
+resource OSD_CS 1 B12
+resource SPI_SCK 2 B13
+resource SPI_MISO 2 B14
+resource SPI_MOSI 2 B15
+
+# FLASH --> SPI3
+resource FLASH_CS 1 A15
+resource SPI_SCK 3 B03
+resource SPI_MISO 3 B04
+resource SPI_MOSI 3 B05
+
+# ADC
+resource ADC_BATT 1 B01
+resource ADC_CURR 1 A04
+
+# Timer list
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A00 AF1
+# pin A00: TIM2 CH1 (AF1)
+timer A01 AF1
+# pin A01: TIM2 CH2 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin A00 0
+# pin A00: DMA1 Stream 5 Channel 3
+dma pin A01 0
+# pin A01: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 3 Channel 6
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature SOFTSERIAL
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 30 2048 115200 57600 0 115200
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_hardware = NONE
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set flash_spi_bus = 3
+set dshot_idle_value = 450
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set mag_hardware = NONE
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
# Betaflight / STM32F411 (S411) 4.1.0 Jun 25 2019 / 10:27:57 (2a6e94d03) MSP API: 1.42

board_name SKYSTARSF411
manufacturer_id SKST

# resources
resource LED 1 C13
resource PPM 1 A03
resource BEEPER 1 B02
resource LED_STRIP 1 A08

# Motor
resource MOTOR 1 A00
resource MOTOR 2 A01
resource MOTOR 3 B06
resource MOTOR 4 B07
resource MOTOR 5 B10
resource MOTOR 6 NONE

# UART1
resource SERIAL_TX 1 A09
resource SERIAL_RX 1 A10

# UART2
resource SERIAL_TX 2 A02
resource SERIAL_RX 2 A03

# SOFTSERIAL1
resource SERIAL_TX 11 B00
resource SERIAL_RX 11 B00

# IIC1
resource I2C_SCL 1 B08
resource I2C_SDA 1 B09

#GYRO & ACC --> SPI1
resource GYRO_CS 1 C15
resource SPI_SCK 1 A05
resource SPI_MISO 1 A06
resource SPI_MOSI 1 A07
resource GYRO_EXTI 1 C14

# OSD --> SPI2
resource OSD_CS 1 B12
resource SPI_SCK 2 B13
resource SPI_MISO 2 B14
resource SPI_MOSI 2 B15

# FLASH --> SPI3
resource FLASH_CS 1 A15
resource SPI_SCK 3 B03
resource SPI_MISO 3 B04
resource SPI_MOSI 3 B05

# ADC
resource ADC_BATT 1 B01
resource ADC_CURR 1 A04

# Timer list
timer A03 AF3
# pin A03: TIM9 CH2 (AF3)
timer A00 AF1
# pin A00: TIM2 CH1 (AF1)
timer A01 AF1
# pin A01: TIM2 CH2 (AF1)
timer B06 AF2
# pin B06: TIM4 CH1 (AF2)
timer B07 AF2
# pin B07: TIM4 CH2 (AF2)
timer B00 AF2
# pin B00: TIM3 CH3 (AF2)
timer B10 AF1
# pin B10: TIM2 CH3 (AF1)
timer A08 AF1
# pin A08: TIM1 CH1 (AF1)


# dma
dma ADC 1 0
# ADC 1: DMA2 Stream 0 Channel 0
dma pin A00 0
# pin A00: DMA1 Stream 5 Channel 3
dma pin A01 0
# pin A01: DMA1 Stream 6 Channel 3
dma pin B00 0
# pin B00: DMA1 Stream 7 Channel 5
dma pin B06 0
# pin B06: DMA1 Stream 0 Channel 2
dma pin B07 0
# pin B07: DMA1 Stream 3 Channel 2
dma pin B10 0
# pin B10: DMA1 Stream 1 Channel 3
dma pin A08 0
# pin A08: DMA2 Stream 3 Channel 6

# feature
feature -RX_PARALLEL_PWM
feature RX_SERIAL
feature SOFTSERIAL
feature TELEMETRY
feature OSD

# serial
serial 0 64 115200 57600 0 115200
serial 30 2048 115200 57600 0 115200

# master
set baro_bustype = I2C
set baro_i2c_device = 1
set baro_hardware = NONE
set serialrx_provider = SBUS
set blackbox_device = SPIFLASH
set flash_spi_bus = 3
set dshot_idle_value = 450
set dshot_burst = AUTO
set dshot_bitbang = OFF
set motor_pwm_protocol = DSHOT600
set current_meter = ADC
set battery_meter = ADC
set mag_hardware = NONE
set beeper_inversion = ON
set beeper_od = OFF
set system_hse_mhz = 8
set max7456_spi_bus = 2
set dashboard_i2c_bus = 1
set gyro_1_bustype = SPI
set gyro_1_spibus = 1
set gyro_1_sensor_align = CW180
set gyro_1_align_yaw = 1800
