### PR TITLE
Remove ESCSERIAL resource from DIAT-MAMBAF722

### DIFF
--- a/configs/default/DIAT-MAMBAF722.config
+++ b/configs/default/DIAT-MAMBAF722.config
@@ -100,7 +100,6 @@ serial 0 64 115200 57600 0 115200
 serial 3 1 19200 57600 0 115200
 
 # EXTRAS
-resource ESCSERIAL 1 B09
 resource PINIO 1 B00
 
 # feature


### PR DESCRIPTION
ESCSERIAL is not supported on F7 and this was generating an error when the custom config was applied.
