### PR TITLE
Fix Revo Nano Mcu type

### DIFF
--- a/configs/default/OPEN-REVONANO.config
+++ b/configs/default/OPEN-REVONANO.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F405 (S405) 4.2.0 Feb  2 2020 / 14:39:25 (30bf9e809f) MSP API: 1.43
+# Betaflight / STM32F411 (S411) 4.2.0 Feb  2 2020 / 14:39:25 (30bf9e809f) MSP API: 1.43
 
 board_name REVONANO
 manufacturer_id OPEN


### PR DESCRIPTION
Revo Nano is using STM32F411 mcu in the legacy target, fixes https://github.com/betaflight/betaflight/issues/9711