### PR TITLE
add default pull on pin to fix non-inverting receivers

### DIFF
--- a/configs/default/FPVM-BETAFLIGHTF4.config
+++ b/configs/default/FPVM-BETAFLIGHTF4.config
@@ -40,6 +40,8 @@ resource OSD_CS 1 B12
 resource GYRO_EXTI 1 C04
 resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
+# this enables non-inverted serial receivers on the SUMD/DSM2 pin
+resource pulldown 1 B08
 
 # timer
 timer B08 AF3


### PR DESCRIPTION
From the discussion in https://github.com/betaflight/betaflight/issues/9736

Fixes a broken SUMD receiver with BF>4.x

Schematic of the board is unknown, so I don't really know what it does and why it is required, but it fixed my issue.