### PR TITLE
AIRB-OMNIBUSF4SD - Add missing I2C

### DIFF
--- a/configs/default/AIRB-OMNIBUSF4SD.config
+++ b/configs/default/AIRB-OMNIBUSF4SD.config
@@ -50,6 +50,8 @@ resource OSD_CS 1 A15
 resource GYRO_EXTI 1 C04
 resource GYRO_CS 1 A04
 resource USB_DETECT 1 C05
+resource I2C_SCL 2 B10
+resource I2C_SDA 2 B11
 
 # timer
 timer B08 AF3


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/9802

Board has SCL/SDA markings shared with UART3. In the original legacy target they were noted, but defaulted to NONE.
