### PR TITLE
Added explicit OSD device type for DALRCF405.

### DIFF
--- a/configs/default/DALR-DALRCF405.config
+++ b/configs/default/DALR-DALRCF405.config
@@ -111,6 +111,7 @@ set current_meter = ADC
 set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
+set osd_displayport_device = MAX7456
 set system_hse_mhz = 8
 set max7456_spi_bus = 3
 set dashboard_i2c_bus = 1


### PR DESCRIPTION
This is required to identify the OSD type as MAX7456 when powered over USB, as the OSD chip is not powered in this case, and 'AUTO' will fall through to MSP.