### PR TITLE
Rename GEPR-GEPRCF7_BT_HD config file.

### DIFF
--- a/configs/default/GEPR-GEPRCF722_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF722_BT_HD.config
@@ -1,6 +1,6 @@
 # Betaflight / STM32F7X2 (S7X2) 4.0.3 Jun  1 2019 / 11:59:57 (094cfc956) MSP API: 1.41
 
-board_name GEPRCF7_BT_HD
+board_name GEPRCF722_BT_HD
 manufacturer_id GEPR
 
 # resources


### PR DESCRIPTION
In order to make users more clear about their board, we deliberately renamed the file.