### PR TITLE
Delete I2C3 definitions from MATEKF405STD target

### DIFF
--- a/configs/default/MTKS-MATEKF405STD.config
+++ b/configs/default/MTKS-MATEKF405STD.config
@@ -29,9 +29,7 @@ resource SERIAL_RX 3 C11
 resource SERIAL_RX 4 A01
 resource SERIAL_RX 5 D02
 resource I2C_SCL 1 B06
-resource I2C_SCL 3 A08
 resource I2C_SDA 1 B07
-resource I2C_SDA 3 C09
 resource LED 1 B09
 resource LED 2 A14
 resource SPI_SCK 1 A05
@@ -123,7 +121,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF722HD.config
+++ b/configs/default/MTKS-MATEKF722HD.config
@@ -24,7 +24,6 @@ resource SERIAL_TX 3 C10
 resource SERIAL_TX 4 A00
 resource SERIAL_TX 5 C12
 resource SERIAL_TX 6 C06
-resource SERIAL_TX 11 A02
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
 resource SERIAL_RX 3 C11


### PR DESCRIPTION
conflict with non-Dshot protocol on S4 and S6. 

If rare users want to use I2C3 on F405-OSD, they can type CLI command to enable I2C3 themselves. 

