### PR TITLE
Added explicit OSD device type for MAMBAF405.

### DIFF
--- a/configs/default/DIAT-MAMBAF405US.config
+++ b/configs/default/DIAT-MAMBAF405US.config
@@ -10,6 +10,7 @@ resource LED 2 C14
 resource BEEPER 1 C13
 set beeper_inversion = ON
 set beeper_od = OFF
+set osd_displayport_device = MAX7456
 
 # ACC/GYRO
 resource GYRO_EXTI 1 C04


### PR DESCRIPTION
Fixes betaflight/betaflight#9823.