### PR TITLE
fix ADC DMA, not work ADC3 DMA2 on 4.2.0, Works ADC1 DMA2

### DIFF
--- a/configs/default/FLMO-GRAVITYF7.config
+++ b/configs/default/FLMO-GRAVITYF7.config
@@ -1,7 +1,7 @@
 # Betaflight / STM32F7X2 (S7X2) 4.1.5 Mar 16 2020 / 05:21:46 (d4e74e39c) MSP API: 1.42
 
 board_name GRAVITYF7
-manufacturer_id FLMD
+manufacturer_id FLMO
 
 # resources
 resource BEEPER 1 C13
@@ -62,8 +62,8 @@ timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
 
 # dma
-dma ADC 3 0
-# ADC 3: DMA2 Stream 0 Channel 2
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 2
 dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 dma pin A09 0
@@ -84,7 +84,7 @@ feature OSD
 
 # master
 set mag_bustype = I2C
-set mag_i2c_device = 1
+set mag_i2c_device = 2
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set baro_i2c_address = 119


### PR DESCRIPTION
fix ADC DMA, not work ADC3 DMA2 on 4.2.0, Works ADC1 DMA2