### PR TITLE
Added configuration for SKYSTARSF405.

### DIFF
--- a/configs/default/SKST-SKYSTARSF405.config
+++ b/configs/default/SKST-SKYSTARSF405.config
@@ -1,0 +1,128 @@
+# Betaflight / STM32F405 (S405) 4.1.0 Oct 16 2019 / 11:57:16 (c37a7c91a) MSP API: 1.42
+
+board_name SKYSTARSF405
+manufacturer_id SKST
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B07
+resource MOTOR 2 B06
+resource MOTOR 3 B04
+resource MOTOR 4 B03
+resource MOTOR 5 B00
+resource MOTOR 6 B01
+resource PPM 1 A08
+resource LED_STRIP 1 C08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
+resource INVERTER 3 C03
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C14
+resource LED 2 C15
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource CAMERA_CONTROL 1 C09
+resource ADC_BATT 1 C00
+resource ADC_RSSI 1 C02
+resource ADC_CURR 1 C01
+resource BARO_CS 1 B02
+resource FLASH_CS 1 A15
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+
+# timer
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+# dma
+dma SPI_TX 3 0
+# SPI_TX 3: DMA1 Stream 5 Channel 0
+dma ADC 2 1
+# ADC 2: DMA2 Stream 3 Channel 1
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 2 1024 19200 57600 0 115200
+serial 5 2048 19200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_spi_device = 2
+set serialrx_provider = SBUS
+set adc_device = 2
+set blackbox_device = SPIFLASH
+set dshot_idle_value = 450
+set dshot_burst = AUTO
+set motor_pwm_protocol = DSHOT600
+set motor_poles = 12
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set camera_control_mode = SOFTWARE_PWM
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180FLIP
+set gyro_1_align_pitch = 1800
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
From Slack:
mikeller￼  3:12 PM
Your configuration contains the following default:
```
set motor_pwm_protocol = DSHOT600
```
If this setting is used as a default, and if your board is used in combination with older ESCs that do not support Dshot, this will result in the motors spinning up as soon as a battery is connected, potentially resulting in damage or injury.
Do you assume all responsibility for personal injury and damage resulting from using this default setting?
hongzhou zeng  3:59 AM
The board name is SKYSTARSF405,
I assume all responsibility for personal injury and damage resulting from using this default setting。