### PR TITLE
Added target for SKYSTARSF7HD.

### DIFF
--- a/configs/default/SKST-SKYSTARSF7HD.config
+++ b/configs/default/SKST-SKYSTARSF7HD.config
@@ -1,0 +1,121 @@
+# Betaflight / STM32F7X2 (S7X2) 4.1.0 Oct 16 2019 / 11:58:45 (c37a7c91a) MSP API: 1.42
+
+board_name SKYSTARSF7HD
+manufacturer_id SKST
+
+# resources
+resource LED 1 C15
+resource LED 2 C14
+resource BEEPER 1 B02
+
+resource MOTOR 1 C08
+resource MOTOR 2 C09
+resource MOTOR 3 A08
+resource MOTOR 4 A09
+resource PPM 1 B04
+resource LED_STRIP 1 B03
+resource CAMERA_CONTROL 1 A10
+resource GYRO_CS 1 A04
+resource SPI_SCK 1 A05
+resource SPI_MISO 1 A06
+resource SPI_MOSI 1 A07
+resource GYRO_EXTI 1 C04
+resource FLASH_CS 1 A15
+resource SPI_SCK 3 C10
+resource SPI_MISO 3 C11
+resource SPI_MOSI 3 B05
+resource OSD_CS 1 B12
+resource SPI_SCK 2 B13
+resource SPI_MISO 2 B14
+resource SPI_MOSI 2 B15
+resource ADC_BATT 1 C01
+resource ADC_RSSI 1 C02
+resource ADC_CURR 1 C03
+resource SERIAL_TX 1 B06
+resource SERIAL_RX 1 B07
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 2 A03
+resource SERIAL_TX 3 B10
+resource SERIAL_RX 3 B11
+resource SERIAL_TX 4 A00
+resource SERIAL_RX 4 A01
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 5 D02
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource PINIO 1 B00
+resource BARO_CS 1 B01
+
+# TIMERS
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH2 (AF1)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+
+# dma
+dma ADC 2 0    
+# ADC 2: DMA2 Stream 3 Channel 1
+dma pin C08 0  
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0  
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A08 0  
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin A09 0  
+# pin A09: DMA2 Stream 6 Channel 0
+dma pin A10 0  
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B03 0  
+# pin B03: DMA1 Stream 6 Channel 3
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature SOFTSERIAL
+feature OSD
+
+# serial
+
+serial 0 64 115200 57600 0 115200
+serial 2 1024 19200 57600 0 115200
+serial 4 2 19200 57600 0 115200
+serial 5 1 115200 57600 0 115200
+
+
+# master
+set camera_control_mode = SOFTWARE_PWM
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_spi_device = 2
+set serialrx_provider = SBUS
+set adc_device = 2
+set dshot_idle_value = 450
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT600
+set align_board_roll = 180
+set align_board_yaw = 90
+set pinio_box = 0,255,255,255
+set pinio_config = 129,1,1,1
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_od = OFF
+set beeper_inversion = ON
+set blackbox_device = SPIFLASH
+set flash_spi_bus = 3
+set max7456_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180


### PR DESCRIPTION
Your configuration contains the following default:
```
set motor_pwm_protocol = DSHOT600
```
If this setting is used as a default, and if your board is used in combination with older ESCs that do not support Dshot, this will result in the motors spinning up as soon as a battery is connected, potentially resulting in damage or injury.
Do you assume all responsibility for personal injury and damage resulting from using this default setting?
￼￼
hongzhou zeng  2:19 PM
Hi mikeller，
I assume all responsibility for personal injury and damage resulting from using this default setting。