### PR TITLE
Add TRANSTECF405HD

### DIFF
--- a/configs/default/TTRH-TRANSTECF405HD.config
+++ b/configs/default/TTRH-TRANSTECF405HD.config
@@ -93,7 +93,6 @@ set baro_hardware = NONE
 set serialrx_provider = SBUS
 set blackbox_device = NONE
 set dshot_burst = ON
-set motor_poles = 12
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC
 set battery_meter = ADC

--- a/configs/default/TTRH-TRANSTECF405HD.config
+++ b/configs/default/TTRH-TRANSTECF405HD.config
@@ -1,0 +1,109 @@
+# Betaflight / STM32F405 (S405) 4.2.0 Jun 14 2020 / 03:04:22 (8f2d21460) MSP API: 1.43
+board_name TRANSTECF405HD
+manufacturer_id TTRH
+
+# name: TransTEC
+
+# resources
+resource BEEPER 1 B04
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 C08
+resource MOTOR 4 C09
+resource LED_STRIP 1 B06
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource INVERTER 1 B08
+resource LED 1 B09
+resource SPI_SCK 1 A05
+resource SPI_MISO 1 A06
+resource SPI_MOSI 1 A07
+resource ADC_BATT 1 C05
+resource ADC_RSSI 1 B01
+resource ADC_CURR 1 C04
+resource GYRO_EXTI 1 C03
+resource GYRO_CS 1 C02
+resource USB_DETECT 1 B12
+
+# timer
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer C07 AF2
+# pin C07: TIM3 CH2 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
+dma pin C07 0
+# pin C07: DMA1 Stream 5 Channel 5
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature LED_STRIP
+feature OSD
+
+# beacon
+beacon RX_SET
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 4 1 115200 57600 0 115200
+
+# led
+led 0 0,0::C:1
+led 1 1,0::C:1
+led 2 2,0::C:1
+led 3 3,0::C:1
+led 4 4,0::C:1
+led 5 5,0::C:1
+led 6 6,0::C:1
+led 7 7,0::C:1
+led 8 8,0::C:1
+
+# aux
+aux 0 0 2 1300 2100 0 0
+aux 1 13 1 1700 2100 0 0
+
+# master
+set mag_hardware = NONE
+set baro_hardware = NONE
+set serialrx_provider = SBUS
+set blackbox_device = NONE
+set dshot_burst = ON
+set motor_poles = 12
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set yaw_motors_reversed = ON
+set osd_current_pos = 2486
+set system_hse_mhz = 8
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set max7456_spi_bus = 0
+set name = TransTEC


### PR DESCRIPTION
Add a new target to support TransTEC new F405 + Blheli_S AIO.
This is only for the DJI FPV system.
