### PR TITLE
Added manufacturer id and maintainer for Shenzhen High Energy Bili Co., Ltd. (CODAR).

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 /configs/default/FOXE-* @Johnsnow-foxeer @betaflight/unified-target-administrators
 /configs/default/GEPR-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/GEFP-* @x4FF3 @betaflight/unified-target-administrators
+/configs/default/HEBI-* @shackelton1978 @betaflight/unified-target-administrators
 /configs/default/HENA-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/HFOR-* @atgfpeyv @betaflight/unified-target-administrators
 /configs/default/HGLR-* @HGLRC-D @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -39,6 +39,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |HAMO|Happymodel|http://www.happymodel.cn/|
 |HARC|HAKRC|https://github.com/loopur|
 |HBRO|Holybro|http://www.holybro.com/index.html|
+|HEBI|Shenzhen High Energy Bili Co., Ltd.|http://www.coddar.net/|
 |HENA|Heli-Nation|https://www.heli-nation.com/|
 |HFOR|HIFIONRC|http://www.hifionrc.com/|
 |HGLR|HGLRC|https://www.hglrc.com/|


### PR DESCRIPTION
Fixes betaflight/betaflight#10058.

@shackelton1978 is it correct that you are going to be the maintainer for these targets?
