### PR TITLE
Set the default mixer for Revolt to QUADX1234.

### DIFF
--- a/configs/default/FLON-REVOLT.config
+++ b/configs/default/FLON-REVOLT.config
@@ -67,6 +67,9 @@ dma pin A02 0
 dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
+# mixer
+mixer QUADX1234
+
 # master
 set dshot_burst = ON
 set system_hse_mhz = 8


### PR DESCRIPTION
Fixes betaflight/betaflight#10017.