### PR TITLE
Fix camera switching to C2 by default on GEPRCF722

### DIFF
--- a/configs/default/GEPR-GEPRCF722.config
+++ b/configs/default/GEPR-GEPRCF722.config
@@ -101,7 +101,7 @@ serial 5 2 115200 57600 0 115200
 
 # aux
 aux 0 0 0 1700 2100 0 0
-aux 1 41 3 1400 2100 0 0
+aux 1 41 3 1800 2100 0 0
 
 # master
 set mag_bustype = I2C


### PR DESCRIPTION
This board has its USER1 mode range set to 1400-2100, thus switching the camera to the C2 pad by default. Fixed by changing default to 1800-2100 - felt that correcting the default was more appropriate than removing the definition. 