### PR TITLE
Removed no longer existing parameter 'gyro_sync_denom' from target configurations.

### DIFF
--- a/configs/default/AIRB-OMNIBUSF4NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF4NANOV7.config
@@ -78,7 +78,6 @@ feature OSD
 serial 0 64 115200 57600 0 115200
 
 # master
-set gyro_sync_denom = 2
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set dshot_burst = ON

--- a/configs/default/AIRB-OMNIBUSF7NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF7NANOV7.config
@@ -77,7 +77,6 @@ feature OSD
 serial 0 64 115200 57600 0 115200
 
 # master
-set gyro_sync_denom = 2
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set dshot_burst = ON

--- a/configs/default/CLRA-CLRACINGF4.config
+++ b/configs/default/CLRA-CLRACINGF4.config
@@ -96,7 +96,6 @@ set sdcard_spi_bus = 2
 set system_hse_mhz = 8
 set max7456_spi_bus = 3
 set flash_spi_bus = 3
-set gyro_sync_denom = 1
 set pid_process_denom = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/TTRH-TRANSTECF411.config
+++ b/configs/default/TTRH-TRANSTECF411.config
@@ -63,7 +63,6 @@ serial 0 64 115200 57600 0 115200
 serial 1 2048 115200 57600 0 115200
 
 # master
-set gyro_sync_denom = 2
 set mag_hardware = NONE
 set baro_hardware = NONE
 set serialrx_provider = SBUS

--- a/configs/default/TTRH-TRANSTECF411HD.config
+++ b/configs/default/TTRH-TRANSTECF411HD.config
@@ -83,7 +83,6 @@ led 7 7,0::C:1
 led 8 8,0::C:1
 
 # master
-set gyro_sync_denom = 2
 set mag_hardware = NONE
 set baro_hardware = NONE
 set serialrx_provider = SBUS

--- a/configs/default/TTRH-TRANSTECF7HD.config
+++ b/configs/default/TTRH-TRANSTECF7HD.config
@@ -91,7 +91,6 @@ serial 1 1 115200 57600 0 115200
 serial 4 2048 115200 57600 0 115200
 
 # master
-set gyro_sync_denom = 2
 set mag_hardware = NONE
 set baro_hardware = NONE
 set serialrx_provider = SBUS


### PR DESCRIPTION
Fixes betaflight/betaflight#10152.