### PR TITLE
Added manufacturer id and maintainer for NeutronRC.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,7 @@
 /configs/default/MTKS-* @MATEKSYS @betaflight/unified-target-administrators
 /configs/default/MZGC-* @JanikProphet @betaflight/unified-target-administrators
 /configs/default/NEBD-* @yangyeah @betaflight/unified-target-administrators
+/configs/default/NERC-* @DusKing1 @betaflight/unified-target-administrators
 /configs/default/NGUA-* @aguindehi @betaflight/unified-target-administrators
 /configs/default/PYDR-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/RCTI-* @mikeller-test @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -56,6 +56,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |MTKS|Matek Systems|http://www.mateksys.com/|
 |MZGC|Manaz GCS|https://www.shop-mzgcs.de/|
 |NEBD|NewBeeDrone|https://newbeedrone.com/|
+|NERC|NeutronRC|https://www.facebook.com/Neutronrc-575638996448880|
 |NGUA|NG.UAVP|https://ng.uavp.ch/Shop|
 |OPEN|OpenPilot|https://librepilot.atlassian.net/wiki/spaces/LPDOC/pages/31588369/Supported+Hardware|
 |PYDR|Pyro-Drone|https://pyrodrone.com/|


### PR DESCRIPTION
Fixes betaflight/betaflight#10171.