### PR TITLE
Fixed broken definition for non-USB-powered MAX7456 on GRAVITYF7.

### DIFF
--- a/configs/default/FLMO-GRAVITYF7.config
+++ b/configs/default/FLMO-GRAVITYF7.config
@@ -97,6 +97,7 @@ set vbat_scale = 111
 set ibata_scale = 182
 set beeper_inversion = ON
 set beeper_od = OFF
+set osd_displayport_device = MAX7456
 set max7456_spi_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI


### PR DESCRIPTION
Fixes betaflight/betaflight-configurator#2175.