### PR TITLE
DroniusF7-Fixed non-usb-powered MAX7456

### DIFF
--- a/configs/default/FOSS-DRONIUSF7.config
+++ b/configs/default/FOSS-DRONIUSF7.config
@@ -100,6 +100,7 @@ set battery_meter = ADC
 set ibata_scale = 119
 set beeper_inversion = ON
 set beeper_od = OFF
+set osd_displayport_device = MAX7456
 set max7456_spi_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI


### PR DESCRIPTION
Another target with broken osd chip definition.