### PR TITLE
Added manufacturer id and maintainer for TUNERC.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@
 /configs/default/TCMM-* @DMAXYANG @betaflight/unified-target-administrators
 /configs/default/TEBS-* @sirPerna @betaflight/unified-target-administrators
 /configs/default/TMTR-* @DieHertz @betaflight/unified-target-administrators
+/configs/default/TURC-* @TUNERC-Aria @betaflight/unified-target-administrators
 /configs/default/TTRH-* @flosean @betaflight/unified-target-administrators
 /configs/default/WIZZ-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/YUPF-* @Faduf @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -76,6 +76,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |TCMM|Shenzhen Xinmumu Science and Technology Co (TCMM)|http://www.tcmm-rc.cn/|
 |TEBS|Team Blacksheep|https://www.team-blacksheep.com/|
 |TMTR|T-motor|http://uav-en.tmotor.com/|
+|TURC|TUNERC|https://www.tunerc.com/|
 |TTRH|TransTEC|http://www.transtechobby.com/|
 |VGRC|V-GOOD Technology Co.|http://www.vgoodrc.com/|
 |VIVA|VivaFPV|https://vivafpv.com/|


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/10283.

@tunerc-aria: I assume it is you who should be registered as the maintainer for the TUNERC targets?