### PR TITLE
Add RUSH-BLADE_F7_HD flight controller support.

### DIFF
--- a/configs/default/RUSH-BLADE_F7_HD.config
+++ b/configs/default/RUSH-BLADE_F7_HD.config
@@ -1,8 +1,4 @@
-# version
-# Betaflight / RUSHFCHD (RF7H) 4.2.1 Aug 13 2020 / 00:11:54 (caa0d683c) MSP API: 1.43
-
-# start the command batch
-batch start
+# Betaflight / STM32F7X2 (S7X2) 4.2.4 Oct 20 2020 / 08:20:06 (fbcaf8c50) MSP API: 1.43
 
 board_name BLADE_F7_HD
 manufacturer_id RUSH

--- a/configs/default/RUSH-BLADE_F7_HD.config
+++ b/configs/default/RUSH-BLADE_F7_HD.config
@@ -1,0 +1,113 @@
+# version
+# Betaflight / RUSHFCHD (RF7H) 4.2.1 Aug 13 2020 / 00:11:54 (caa0d683c) MSP API: 1.43
+
+# start the command batch
+batch start
+
+board_name BLADE_F7_HD
+manufacturer_id RUSH
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 C08
+resource MOTOR 2 C09
+resource MOTOR 3 B01
+resource MOTOR 4 B00
+resource MOTOR 5 C07
+resource MOTOR 6 C06
+resource LED_STRIP 1 A15
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B10
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource ADC_BATT 1 C00
+resource ADC_CURR 1 C01
+resource FLASH_CS 1 B12
+resource GYRO_EXTI 1 A04
+resource GYRO_CS 1 C04
+
+# timer
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
+dma pin C06 0
+# pin C06: DMA2 Stream 2 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature OSD
+feature ESC_SENSOR
+feature LED_STRIP
+
+# serial
+serial 1 64 115200 57600 0 115200
+serial 2 1024 115200 57600 0 115200
+serial 3 1 115200 57600 0 115200
+
+# led
+led 0 0,15::C:2
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270
+set gyro_1_align_yaw = 2700


### PR DESCRIPTION
We use a plug-in socket for DJI's connector and provide two types of wires, so if the user decides not to use DJI air unit's build-in S.Bus line, they can use UART1 or UART5, and we'll take the risk of this, and will remind users on our website and in manual.