### PR TITLE
ADD  VGRC-VGOODRCF411_DJI  targets config

### DIFF
--- a/configs/default/VGRC-VGOODRCF411_DJI.config
+++ b/configs/default/VGRC-VGOODRCF411_DJI.config
@@ -1,0 +1,104 @@
+board_name VGOODRCF411_DJI
+manufacturer_id VGRC
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 B03
+resource MOTOR 2 B04
+resource MOTOR 3 B06
+resource MOTOR 4 B07
+resource PPM 1 B09
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource INVERTER 1 B10
+resource LED 1 C13
+resource LED 2 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource ESCSERIAL 1 B09
+resource ADC_BATT 1 A00
+resource ADC_RSSI 1 B01
+resource ADC_CURR 1 A01
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 B00
+resource GYRO_CS 1 A04
+
+# timer
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B08 AF3
+# pin B08: TIM10 CH1 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature MOTOR_STOP
+feature TELEMETRY
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 64 115200 57600 0 115200
+
+# led
+led 0 0,15::ATI:0
+led 1 1,15::ATI:0
+led 2 2,15::ATI:0
+led 3 3,15::ATI:0
+led 4 4,15::ATI:0
+led 5 5,15::ATI:0
+led 6 6,15::ATI:0
+
+# aux
+aux 0 0 0 1700 2100 0 0
+
+# master
+set acc_calibration = 0,-23,-400
+set serialrx_provider = SBUS
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
Hi Mikeller,
For the  safety about default with Dshot 600:
We sell this controller with our latest BLHeli_32 ESC and our ESC default also with Dshot600, at the same time, we will write and enhance this safety instruction in our FC manual. We will take responsibility for any safety issue if there. tks.