### PR TITLE
change mapping on motor 1 to  motor 4 to match hardware, and change default Serial RX to UART2 

### DIFF
--- a/configs/default/WIZZ-WIZZF7HD.config
+++ b/configs/default/WIZZ-WIZZF7HD.config
@@ -5,10 +5,10 @@ manufacturer_id WIZZ
 
 # resources
 resource BEEPER 1 B04
-resource MOTOR 1 B06
-resource MOTOR 2 B07
-resource MOTOR 3 B08
-resource MOTOR 4 B09
+resource MOTOR 1 B09
+resource MOTOR 2 B08
+resource MOTOR 3 B07
+resource MOTOR 4 B06
 resource MOTOR 5 A08
 resource MOTOR 6 C08
 resource MOTOR 7 B01
@@ -78,7 +78,7 @@ feature RX_SERIAL
 feature OSD
 
 # serial
-serial 4 64 115200 57600 0 115200
+serial 1 64 115200 57600 0 115200
 
 # master
 set mag_bustype = I2C


### PR DESCRIPTION
Since the final hardware has the change on motor mapping and the default Serial Mounting UART. 

update the target to matching the final hardware