### PR TITLE
solved TIMER/DMA issue with M6 and M3 && added M7 and M8 resources

### DIFF
--- a/configs/default/TMTR-TMOTORF7.config
+++ b/configs/default/TMTR-TMOTORF7.config
@@ -11,6 +11,8 @@ resource MOTOR 3 B00
 resource MOTOR 4 B01
 resource MOTOR 5 B06
 resource MOTOR 6 B08
+resource MOTOR 7 B07
+resource MOTOR 8 C09
 resource PPM 1 A15
 resource LED_STRIP 1 A08
 resource SERIAL_TX 1 A09
@@ -47,12 +49,12 @@ resource GYRO_CS 1 A04
 resource PINIO 1 C14
 
 # timer
-timer C06 AF3
-# pin C06: TIM8 CH1 (AF3)
-timer C07 AF3
-# pin C07: TIM8 CH2 (AF3)
-timer B00 AF2
-# pin B00: TIM3 CH3 (AF2)
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer C07 AF2
+# pin C07: TIM3 CH2 (AF2)
+timer B00 AF3
+# pin B00: TIM8 CH2N (AF3)
 timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
 timer B06 AF2
@@ -65,16 +67,19 @@ timer B09 AF3
 # pin B09: TIM11 CH1 (AF3)
 timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
 # dma
 dma ADC 1 1
 # ADC 1: DMA2 Stream 4 Channel 0
-dma pin C06 1
-# pin C06: DMA2 Stream 2 Channel 7
-dma pin C07 1
-# pin C07: DMA2 Stream 3 Channel 7
+dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
+dma pin C07 0
+# pin C07: DMA1 Stream 5 Channel 5
 dma pin B00 0
-# pin B00: DMA1 Stream 7 Channel 5
+# pin B00: DMA2 Stream 2 Channel 0
 dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 dma pin B06 0
@@ -85,6 +90,11 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+
 
 # feature
 feature OSD

--- a/configs/default/TMTR-TMOTORF7.config
+++ b/configs/default/TMTR-TMOTORF7.config
@@ -71,6 +71,7 @@ timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
 timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
+
 # dma
 dma ADC 1 1
 # ADC 1: DMA2 Stream 4 Channel 0


### PR DESCRIPTION

Changed Motor6 and Motor3 DMA/Timer conflict: once selected 6 motor output the M3 and M6 where in conflict as using same DMA. 

Added Motor7 and Motor8 resource pin, timer and DMA.