### PR TITLE
add Set mco2_on_pc9 to on as default for new AIO board

### DIFF
--- a/configs/default/CLRA-CLRACINGF7.config
+++ b/configs/default/CLRA-CLRACINGF7.config
@@ -152,3 +152,4 @@ set gyro_2_align_yaw = 900
 set gyro_to_use = BOTH
 set pinio_config = 1,1,1,1
 set pinio_box = 40,255,255,255
+set mco2_on_pc9 = ON


### PR DESCRIPTION
Set the mco2_on_pc9 to default on for the new AIO F7 without OSD oscillator.
