### PR TITLE
BARO_CS actually USES C05

### DIFF
--- a/configs/default/SKST-SKYSTARSF405.config
+++ b/configs/default/SKST-SKYSTARSF405.config
@@ -43,7 +43,7 @@ resource CAMERA_CONTROL 1 C09
 resource ADC_BATT 1 C00
 resource ADC_RSSI 1 C02
 resource ADC_CURR 1 C01
-resource BARO_CS 1 B02
+resource BARO_CS 1 C05
 resource FLASH_CS 1 A15
 resource OSD_CS 1 B12
 resource GYRO_EXTI 1 C04


### PR DESCRIPTION
Hi, everybody.
I will Replace hongzhou-zeng to maintain all objectives.

For this firmware, in our flight control on shipment,BARO_CS actually USES C05.

Thank you.

