### PR TITLE
Add TransTECF411AIO target

### DIFF
--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -18,8 +18,6 @@ resource SERIAL_TX 2 A02
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
 resource INVERTER 1 A14
-resource I2C_SCL 1 B08
-resource I2C_SDA 1 B09
 resource LED 1 C13
 resource LED 2 C14
 resource SPI_SCK 1 A05
@@ -103,18 +101,9 @@ aux 2 13 1 1700 2100 0 0
 aux 3 35 0 1700 2100 0 0
 
 # master
-set dyn_notch_width_percent = 0
-set dyn_notch_q = 250
-set mag_bustype = I2C
-set mag_i2c_device = 1
-set mag_hardware = NONE
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set baro_hardware = NONE
-set min_check = 1030
-set max_check = 1995
-set serialrx_provider = SBUS
-set blackbox_device = NONE
 set dshot_idle_value = 600
 set dshot_burst = AUTO
 set dshot_bidir = ON
@@ -127,7 +116,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set yaw_motors_reversed = ON
-set small_angle = 90
 set osd_current_pos = 2486
 set osd_craft_name_pos = 2112
 set system_hse_mhz = 8

--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -1,0 +1,138 @@
+# Betaflight / STM32F411 (S411) 4.2.4 Oct 20 2020 / 08:19:06 (fbcaf8c50) MSP API: 1.43
+
+board_name TRANSTECF411AIO
+manufacturer_id TTRH
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 B04
+resource MOTOR 2 B05
+resource MOTOR 3 B06
+resource MOTOR 4 B07
+resource MOTOR 5 B03
+resource MOTOR 6 B10
+resource PPM 1 A03
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource INVERTER 1 A14
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C13
+resource LED 2 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource ADC_BATT 1 B00
+resource ADC_CURR 1 B01
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 A01
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C15
+
+# timer
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin A02 0
+# pin A02: DMA1 Stream 0 Channel 6
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature LED_STRIP
+feature OSD
+
+# beacon
+beacon RX_SET
+
+# serial
+serial 0 64 115200 57600 0 115200
+serial 1 1 115200 57600 0 115200
+
+# led
+led 0 0,0::L:1
+led 1 1,0::L:1
+
+# aux
+aux 0 0 2 1300 2100 0 0
+aux 1 1 2 1300 1700 0 0
+aux 2 13 1 1700 2100 0 0
+aux 3 35 0 1700 2100 0 0
+
+# master
+set dyn_notch_width_percent = 0
+set dyn_notch_q = 250
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set mag_hardware = NONE
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_hardware = NONE
+set min_check = 1030
+set max_check = 1995
+set serialrx_provider = SBUS
+set blackbox_device = NONE
+set dshot_idle_value = 600
+set dshot_burst = AUTO
+set dshot_bidir = ON
+set dshot_bitbang = OFF
+set motor_pwm_protocol = DSHOT300
+set motor_poles = 12
+set vbat_max_cell_voltage = 450
+set current_meter = ADC
+set battery_meter = ADC
+set beeper_inversion = ON
+set beeper_od = OFF
+set yaw_motors_reversed = ON
+set small_angle = 90
+set osd_current_pos = 2486
+set osd_craft_name_pos = 2112
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set name = TransTEC

--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -101,9 +101,6 @@ aux 2 13 1 1700 2100 0 0
 aux 3 35 0 1700 2100 0 0
 
 # master
-set baro_bustype = I2C
-set baro_i2c_device = 1
-set baro_hardware = NONE
 set dshot_idle_value = 600
 set dshot_burst = AUTO
 set dshot_bidir = ON


### PR DESCRIPTION
Add TransTEC F411 AIO new board target.
This is an AIO board that design for specific Frame, and default setting of ESC support RPM filter.
