### PR TITLE
add JHEF411 unified target

### DIFF
--- a/configs/default/JHEF-JHEF411.config
+++ b/configs/default/JHEF-JHEF411.config
@@ -1,0 +1,113 @@
+# Betaflight / STM32F411 (S411) 4.2.0 Jun 14 2020 / 03:04:43 (8f2d21460) MSP API: 1.43
+
+board_name JHEF411
+manufacturer_id JHEF
+
+# resources
+resource BEEPER 1 C14
+resource MOTOR 1 A08
+resource MOTOR 2 A09
+resource MOTOR 3 A10
+resource MOTOR 4 B00
+resource MOTOR 5 B04
+resource PPM 1 A02
+resource PWM 1 B01
+resource PWM 2 A03
+resource LED_STRIP 1 A15
+resource SERIAL_TX 1 B06
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 1 B07
+resource SERIAL_RX 2 A03
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C13
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource CAMERA_CONTROL 1 B10
+resource ADC_BATT 1 A00
+resource ADC_RSSI 1 B01
+resource ADC_CURR 1 A01
+resource PINIO 1 B05
+resource FLASH_CS 1 B02
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 B03
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C15
+
+# timer
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin A08 1
+# pin A08: DMA2 Stream 1 Channel 6
+dma pin A09 1
+# pin A09: DMA2 Stream 2 Channel 6
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A03 1
+# pin A03: DMA1 Stream 3 Channel 6
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+
+# feature
+feature OSD
+feature RX_SERIAL
+
+#serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT300
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 170
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800
+set gyro_2_spibus = 1


### PR DESCRIPTION
This is the config for the GHF411 PRO AIO.

http://www.jhemcu.com/e_productshow/?17-JHEMCU-GHF411AIO-F4-OSD-FLIGHT-CONTROLLER-BUILT-IN-30A-BL_S-2-4S-4IN1-ESC-FOR-TOOTHPICK-17.html

They ship it with BF 4.2 pre-flashed with a custom target. Unfortunately, they're using "JHE" for the manufacturer ID. Not sure if this is important in some way as BF actually uses "JHEF".

As @atgfpeyv is the official contact for JHE, you might want to have another look into this.