### PR TITLE
Added manufacturer id and maintainer for Huizhou NIDICI Electronic Co., LTD.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,6 +70,7 @@
 /configs/default/HENA-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/HFOR-* @atgfpeyv @betaflight/unified-target-administrators
 /configs/default/HGLR-* @HGLRC-D @betaflight/unified-target-administrators
+/configs/default/HNEC-* @WilsonChang @betaflight/unified-target-administrators
 /configs/default/HOWI-* @Project399 @betaflight/unified-target-administrators
 /configs/default/IFRC-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/LDAR-* @Linjieqiang @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -45,6 +45,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |HENA|Heli-Nation|https://www.heli-nation.com/|
 |HFOR|HIFIONRC|http://www.hifionrc.com/|
 |HGLR|HGLRC|https://www.hglrc.com/|
+|HNEC|Huizhou NIDICI Electronic Co., LTD|https://shop.nidici.com/|
 |HOWI|Hobbywing Technology CO., LTD.|http://hobbywing.com/|
 |IFRC|iFlight Innovation Technology Ltd.|https://www.iflight-rc.com/|
 |JHEF|JHE\_FPV|https://github.com/atgfpeyv|


### PR DESCRIPTION
Fixes https://github.com/betaflight/unified-targets/issues/421.