### PR TITLE
Update DALRCF722DUAL unified config

### DIFF
--- a/configs/default/DALR-DALRCF722DUAL.config
+++ b/configs/default/DALR-DALRCF722DUAL.config
@@ -107,6 +107,7 @@ set blackbox_device = SPIFLASH
 set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC
+set vbat_scale = 160
 set ibata_scale = 166
 set beeper_inversion = ON
 set beeper_od = OFF


### PR DESCRIPTION
The vbat scale not use default scale 110,should be 160.