### PR TITLE
Add Motors to MAMBA

### DIFF
--- a/configs/default/DIAT-MAMBAF405US.config
+++ b/configs/default/DIAT-MAMBAF405US.config
@@ -81,10 +81,22 @@ timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
 resource MOTOR 1 A09
 resource MOTOR 2 A08
 resource MOTOR 3 C09
 resource MOTOR 4 C08
+resource MOTOR 5 B00
+resource MOTOR 6 B01
+resource MOTOR 7 A10
+resource MOTOR 8 B04
 resource PPM 1 B09
 resource LED_STRIP 1 B03
 resource CAMERA_CONTROL 1 B08
@@ -104,6 +116,14 @@ dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
 
 # FEATURE
 feature -RX_PARALLEL_PWM

--- a/configs/default/DIAT-MAMBAF405US_I2C.config
+++ b/configs/default/DIAT-MAMBAF405US_I2C.config
@@ -84,10 +84,22 @@ timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
 resource MOTOR 1 A09
 resource MOTOR 2 A08
 resource MOTOR 3 C09
 resource MOTOR 4 C08
+resource MOTOR 5 B00
+resource MOTOR 6 B01
+resource MOTOR 7 A10
+resource MOTOR 8 B04
 resource LED_STRIP 1 B03
 
 # DMA
@@ -105,6 +117,14 @@ dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
 
 # FEATURE
 feature -RX_PARALLEL_PWM
@@ -123,6 +143,8 @@ resource PINIO 1 B00
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set mag_bustype = I2C
+set mag_i2c_device = 1
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set dshot_burst = ON

--- a/configs/default/DIAT-MAMBAF722.config
+++ b/configs/default/DIAT-MAMBAF722.config
@@ -78,22 +78,48 @@ timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
 resource MOTOR 1 C08
 resource MOTOR 2 C09
 resource MOTOR 3 A08
 resource MOTOR 4 A09
+resource MOTOR 5 B00
+resource MOTOR 6 B01
+resource MOTOR 7 A10
+resource MOTOR 8 B04
 resource PPM 1 B09
 resource LED_STRIP 1 B03
 resource CAMERA_CONTROL 1 B08
 
 # dma
 dma ADC 3 0    # ADC 3: DMA2 Stream 0 Channel 2
-dma pin C08 0  # pin C08: DMA2 Stream 2 Channel 0
-dma pin C09 0  # pin C09: DMA2 Stream 7 Channel 7
-dma pin A08 0  # pin A08: DMA2 Stream 6 Channel 0
-dma pin A09 0  # pin A09: DMA2 Stream 6 Channel 0
-dma pin B08 0  # pin B08: DMA1 Stream 7 Channel 2
-dma pin B03 0  # pin B03: DMA1 Stream 6 Channel 3
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin A09 0
+# pin A09: DMA2 Stream 6 Channel 0
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
 
 # serial
 serial 0 64 115200 57600 0 115200

--- a/configs/default/DIAT-MAMBAF722_I2C.config
+++ b/configs/default/DIAT-MAMBAF722_I2C.config
@@ -82,10 +82,22 @@ timer B08 AF2
 # pin B08: TIM4 CH3 (AF2)
 timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
 resource MOTOR 1 C08
 resource MOTOR 2 C09
 resource MOTOR 3 A08
 resource MOTOR 4 A09
+resource MOTOR 5 B00
+resource MOTOR 6 B01
+resource MOTOR 7 A10
+resource MOTOR 8 B04
 resource LED_STRIP 1 B03
 
 # dma
@@ -103,6 +115,14 @@ dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A10 0
+# pin A10: DMA2 Stream 6 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
 
 # serial
 serial 0 64 115200 57600 0 115200
@@ -120,6 +140,8 @@ feature OSD
 # master
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set mag_bustype = I2C
+set mag_i2c_device = 1
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set dshot_burst = ON


### PR DESCRIPTION
Per request of Diatone, added 4 motor controls to the Uniifed Target.  Board had spare pins so they are adding to target.   I've checked for Timer clashes and there are none.  Will not affect existing target.   Already has DSHOT DMAR enabled so no DMA conflicts found.   There is one DMA issue if disabled, but there are already ones existing in original target that user would have to mitigate.   Thanks Michael!