### PR TITLE
Remove vtxtable from GEPR-GEPRCF722_BT_HD

### DIFF
--- a/configs/default/GEPR-GEPRCF722_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF722_BT_HD.config
@@ -112,19 +112,6 @@ serial 1 64 115200 57600 0 115200
 serial 3 1 19200 57600 0 115200
 serial 4 1024 19200 57600 0 115200
 
-# vtxtable
-vtxtable bands 6
-vtxtable channels 8
-vtxtable band 1 BOSCAM_A A CUSTOM  5865 5845 5825 5805 5785 5765 5745 5725
-vtxtable band 2 BOSCAM_B B CUSTOM  5733 5752 5771 5790 5809 5828 5847 5866
-vtxtable band 3 BOSCAM_E E CUSTOM  5705 5685 5665 5645 5885 5905 5925 5945
-vtxtable band 4 FATSHARK F CUSTOM  5740 5760 5780 5800 5820 5840 5860 5880
-vtxtable band 5 RACEBAND R CUSTOM  5658 5695 5732 5769 5806 5843 5880 5917
-vtxtable band 6 BAND_D   D CUSTOM  5362 5399 5436 5473 5510 5547 5584 5621
-vtxtable powerlevels 5
-vtxtable powervalues 25 100 200 400 600
-vtxtable powerlabels 25 100 200 400 600
-
 # master
 set gyro_to_use = BOTH
 set baro_bustype = I2C


### PR DESCRIPTION
Not sure how this slipped through, but unified target configs cannot contain a `vtxtable`. There is no way to make a table that is guaranteed to be legal for all users.