### PR TITLE
Update DIAT_FURYF4OSD to enable I2C baro/mag

### DIFF
--- a/configs/default/DIAT-FURYF4OSD.config
+++ b/configs/default/DIAT-FURYF4OSD.config
@@ -83,16 +83,17 @@ feature OSD
 serial 2 8192 115200 57600 0 115200
 
 # master
-set rssi_src_frame_errors = ON
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
-set dshot_idle_value = 300
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC
 set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
-set pid_process_denom = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set mag_bustype = I2C
+set mag_i2c_address = 1
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set dashboard_i2c_bus = 1
@@ -100,4 +101,3 @@ set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180
-set gyro_2_spibus = 1


### PR DESCRIPTION
Fixes #398 (and many other github/slack/Facebook issues)

Board has I2C pads but target was not configured to allow users to connect baro/mag resulting in many support issues.

Also removed some other inappropriate settings from the target config:

`set rssi_src_frame_errors = ON` - This is a user preference and also based on the type of radio link used and shouldn't be in the target config.

`set dshot_idle_value = 300` - This is a user preference setting based on the motors/ESCs used. This is a quite low value and could cause motor de-syncs for some users. Board is not an "AIO" sold with motors/ESCs so not appropriate to define this in the target config.

`set pid_process_denom = 1` - This is the default value so it shouldn't be also defined in the target config.

`set gyro_2_spibus = 1` - The board doesn't have a second gyro or even the resources defined for gyro 2.


