### PR TITLE
add timer define for camera control to match hardware

### DIFF
--- a/configs/default/WIZZ-WIZZF7HD.config
+++ b/configs/default/WIZZ-WIZZF7HD.config
@@ -64,6 +64,8 @@ timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
 timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
 
 # dma
 dma ADC 1 1
@@ -72,6 +74,8 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
 
 # feature
 feature RX_SERIAL


### PR DESCRIPTION
add timer 2 channel 2 , and DMA pin b03 as camera stick control.