### PR TITLE
Added manufacturer id and maintainer for GE-FPV.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@
 /configs/default/FOXE-* @Johnsnow-foxeer @betaflight/unified-target-administrators
 /configs/default/GEPR-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/GEFP-* @x4FF3 @betaflight/unified-target-administrators
+/configs/default/GFPV-* @GEME-Cyi @betaflight/unified-target-administrators
 /configs/default/HAMO-* @githubDLG @betaflight/unified-target-administrators
 /configs/default/HEBI-* @shackelton1978 @betaflight/unified-target-administrators
 /configs/default/HENA-* @bnn1044 @betaflight/unified-target-administrators

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -38,6 +38,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FRSK|FrSky|https://www.frsky-rc.com/|
 |GEFP|GetFPV LLC|https://www.getfpv.com/|
 |GEPR|GEPRC|https://geprc.com/|
+|GFPV|GE-FPV|http://www.ge-fpv.com/|
 |HAMO|Happymodel|http://www.happymodel.cn/|
 |HARC|HAKRC|https://github.com/loopur|
 |HBRO|Holybro|http://www.holybro.com/index.html|


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight/issues/10627.