### PR TITLE
Reassign pin B01 from AF1 to AF2 to use TIM3 rather than TIM1 on FURYF4OSD

### DIFF
--- a/configs/default/DIAT-FURYF4OSD.config
+++ b/configs/default/DIAT-FURYF4OSD.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F405 (S405) 4.1.0 May 11 2019 / 13:09:51 (a8e9dd94e) MSP API: 1.42
+# Betaflight / STM32F405 (S405) 4.3.0 Apr 27 2021 / 18:42:02 (3ae7e91) MSP API: 1.44
 
 board_name FURYF4OSD
 manufacturer_id DIAT
@@ -49,8 +49,8 @@ timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
 timer B00 AF2
 # pin B00: TIM3 CH3 (AF2)
-timer B01 AF1
-# pin B01: TIM1 CH3N (AF1)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
 timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
 timer A00 AF2
@@ -68,7 +68,7 @@ dma pin A03 1
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 dma pin B01 0
-# pin B01: DMA2 Stream 6 Channel 0
+# pin B01: DMA1 Stream 2 Channel 5
 dma pin A02 0
 # pin A02: DMA1 Stream 1 Channel 3
 dma pin A00 0


### PR DESCRIPTION
This moves MOTOR 3 to DMA1 Stream 2 and thus enables the use DMA2 streams 0 and 3 for DMA access to the gyro as well as OSD and onboard FLASH.

```
Currently active DMA:
--------------------
DMA1 Stream 0: FLASH_CS
DMA1 Stream 1: MOTOR 4
DMA1 Stream 2: MOTOR 3
DMA1 Stream 3: OSD_CS
DMA1 Stream 4: OSD_CS
DMA1 Stream 5: FLASH_CS
DMA1 Stream 6: MOTOR 1
DMA1 Stream 7: MOTOR 2
DMA2 Stream 0: GYRO_CS
DMA2 Stream 1: FREE
DMA2 Stream 2: FREE
DMA2 Stream 3: GYRO_CS
DMA2 Stream 4: ADC 1
DMA2 Stream 5: FREE
DMA2 Stream 6: FREE
DMA2 Stream 7: FREE
```

This will be of relevance when https://github.com/betaflight/betaflight/pull/10573 is merged as it allows all four motors to be configured without falling foul of https://www.st.com/resource/en/errata_sheet/dm00037591-stm32f405407xx-and-stm32f415417xx-device-limitations-stmicroelectronics.pdf section 2.1.10 which reports an errata that corruption may occurs on DMA2 if AHB peripherals (eg GPIO ports) are accessed concurrently with APB peripherals (eg SPI busses). 