### PR TITLE
Add HybridG4 target

### DIFF
--- a/configs/default/NEUT-HYBRIDG4.config
+++ b/configs/default/NEUT-HYBRIDG4.config
@@ -1,0 +1,104 @@
+# Betaflight / STM32G47X (SG47) 4.3.0 Apr 27 2021 / 03:49:09 (e228d797c) MSP API: 1.44
+
+board_name HYBRIDG4
+manufacturer_id NEUT
+
+# resources
+resource BEEPER 1 C14
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 B02
+resource MOTOR 4 B03
+resource PPM 1 A02
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource I2C_SCL 1 A15
+resource I2C_SDA 1 B07
+resource LED 1 C15
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ESCSERIAL 1 C06
+resource CAMERA_CONTROL 1 B06
+resource ADC_BATT 1 A00
+resource ADC_CURR 1 A01
+resource FLASH_CS 1 B09
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+
+# timer
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer B02 AF2
+# pin B02: TIM5 CH1 (AF2)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer A08 AF6
+# pin A08: TIM1 CH1 (AF6)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A02 AF9
+# pin A02: TIM15 CH1 (AF9)
+
+# dma
+dma ADC 1 12
+# ADC 1: DMA2 Channel 5 Request 5
+dma ADC 4 0
+# ADC 4: DMA1 Channel 1 Request 38
+dma ADC 5 0
+# ADC 5: DMA1 Channel 1 Request 39
+dma TIMUP 3 0
+# TIMUP 3: DMA1 Channel 1 Request 65
+dma TIMUP 4 0
+# TIMUP 4: DMA1 Channel 1 Request 71
+dma TIMUP 5 0
+# TIMUP 5: DMA1 Channel 1 Request 76
+dma pin B00 0
+# pin B00: DMA1 Channel 1 Request 63
+dma pin B01 1
+# pin B01: DMA1 Channel 2 Request 64
+dma pin B02 2
+# pin B02: DMA1 Channel 3 Request 72
+dma pin B03 3
+# pin B03: DMA1 Channel 4 Request 57
+dma pin A08 8
+# pin A08: DMA2 Channel 1 Request 42
+dma pin B06 0
+# pin B06: DMA1 Channel 1 Request 67
+dma pin A02 0
+# pin A02: DMA1 Channel 1 Request 78
+
+# serial
+serial 0 2048 115200 57600 0 115200
+serial 1 64 115200 57600 0 115200
+serial 2 1024 115200 57600 0 115200
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = SPIFLASH
+set align_board_yaw = 270
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set debug_mode = GYRO_SCALED
+set max7456_spi_bus = 2
+set led_inversion = 1
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1

--- a/configs/default/NEUT-HYBRIDG4.config
+++ b/configs/default/NEUT-HYBRIDG4.config
@@ -91,14 +91,13 @@ serial 2 1024 115200 57600 0 115200
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
-set align_board_yaw = 270
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
-set debug_mode = GYRO_SCALED
 set max7456_spi_bus = 2
 set led_inversion = 1
 set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
+set gyro_1_align_yaw = 2700


### PR DESCRIPTION
Add an G474 target for the coming HybridG4 FC, this is the same pinmap as the G474 prototype board V1.1.

I'm not sure about the TIMUP part, as this is ported from the old legacy test firmware.