### PR TITLE
Removed dashboard configuration for STM32F411 and STM32F7X2 targets.

### DIFF
--- a/configs/default/AIKO-AIKONF7.config
+++ b/configs/default/AIKO-AIKONF7.config
@@ -105,7 +105,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/AIRB-AG3XF7.config
+++ b/configs/default/AIRB-AG3XF7.config
@@ -124,7 +124,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/AIRB-AIRBOTF7.config
+++ b/configs/default/AIRB-AIRBOTF7.config
@@ -82,7 +82,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3

--- a/configs/default/AIRB-AIRBOTF7HDV.config
+++ b/configs/default/AIRB-AIRBOTF7HDV.config
@@ -85,7 +85,6 @@ set battery_meter = ADC
 set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/AIRB-HELSEL_STRIKERF7.config
+++ b/configs/default/AIRB-HELSEL_STRIKERF7.config
@@ -84,7 +84,6 @@ set battery_meter = ADC
 set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW90

--- a/configs/default/AIRB-OMNINXT7.config
+++ b/configs/default/AIRB-OMNINXT7.config
@@ -140,7 +140,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/APEX-APEXF7.config
+++ b/configs/default/APEX-APEXF7.config
@@ -93,7 +93,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_config = 129,129,1,1
 set pinio_box = 0,40,255,255
 set flash_spi_bus = 1

--- a/configs/default/BEFH-BETAFPVF411.config
+++ b/configs/default/BEFH-BETAFPVF411.config
@@ -109,7 +109,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/CLRA-CLRACINGF7.config
+++ b/configs/default/CLRA-CLRACINGF7.config
@@ -141,7 +141,6 @@ set sdcard_detect_inverted = ON
 set sdcard_mode = SPI
 set sdcard_spi_bus = 2
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set pinio_box = 39,255,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/CUST-SIRMIXALOT.config
+++ b/configs/default/CUST-SIRMIXALOT.config
@@ -147,7 +147,6 @@ set vtx_power = 1
 set vtx_freq = 5825
 set max7456_spi_bus = 3
 set led_inversion = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/DALR-DALRCF722DUAL.config
+++ b/configs/default/DALR-DALRCF722DUAL.config
@@ -112,7 +112,6 @@ set ibata_scale = 166
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/DFRA-DFR_F722_DUAL_HD.config
+++ b/configs/default/DFRA-DFR_F722_DUAL_HD.config
@@ -124,7 +124,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/DRCL-ELINF722.config
+++ b/configs/default/DRCL-ELINF722.config
@@ -152,7 +152,6 @@ set osd_compass_bar_pos = 106
 set osd_warnings_pos = 2377
 set vcd_video_system = NTSC
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/EXUA-EXF722DUAL.config
+++ b/configs/default/EXUA-EXF722DUAL.config
@@ -130,7 +130,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FLCO-FLYCOLORF7.config
+++ b/configs/default/FLCO-FLYCOLORF7.config
@@ -131,7 +131,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set pid_process_denom = 4
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/FLCO-FLYCOLORF7_AIO.config
+++ b/configs/default/FLCO-FLYCOLORF7_AIO.config
@@ -127,7 +127,6 @@ set ibata_scale = 450
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/FLWO-FLYWOOF411.config
+++ b/configs/default/FLWO-FLYWOOF411.config
@@ -108,7 +108,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/FLWO-FLYWOOF411EVO_HD.config
+++ b/configs/default/FLWO-FLYWOOF411EVO_HD.config
@@ -96,7 +96,6 @@ set beeper_inversion = ON
 set beeper_od = OFF			   
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FLWO-FLYWOOF411HEX.config
+++ b/configs/default/FLWO-FLYWOOF411HEX.config
@@ -100,7 +100,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FLWO-FLYWOOF411V2.config
+++ b/configs/default/FLWO-FLYWOOF411V2.config
@@ -98,7 +98,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FLWO-FLYWOOF7DUAL.config
+++ b/configs/default/FLWO-FLYWOOF7DUAL.config
@@ -131,7 +131,6 @@ set ibata_scale = 170
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/FOSS-ANYFCM7.config
+++ b/configs/default/FOSS-ANYFCM7.config
@@ -126,7 +126,6 @@ set blackbox_device = SPIFLASH
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FOXE-FOXEERF722DUAL.config
+++ b/configs/default/FOXE-FOXEERF722DUAL.config
@@ -104,7 +104,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/FOXE-FOXEERF722V2.config
+++ b/configs/default/FOXE-FOXEERF722V2.config
@@ -104,7 +104,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/GEPR-GEPRCF411.config
+++ b/configs/default/GEPR-GEPRCF411.config
@@ -108,7 +108,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/GEPR-GEPRCF722.config
+++ b/configs/default/GEPR-GEPRCF722.config
@@ -119,7 +119,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set gps_provider = UBLOX
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/GEPR-GEPRCF722_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF722_BT_HD.config
@@ -129,7 +129,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/HARC-HAKRCF411.config
+++ b/configs/default/HARC-HAKRCF411.config
@@ -86,7 +86,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270

--- a/configs/default/HARC-HAKRCF722.config
+++ b/configs/default/HARC-HAKRCF722.config
@@ -97,7 +97,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/HENA-TALONF7DJIHD.config
+++ b/configs/default/HENA-TALONF7DJIHD.config
@@ -135,7 +135,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set pid_process_denom = 1
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set pinio_box = 40,255,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/HENA-TALONF7FUSION.config
+++ b/configs/default/HENA-TALONF7FUSION.config
@@ -99,7 +99,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set pid_process_denom = 1
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/HENA-TALONF7V2.config
+++ b/configs/default/HENA-TALONF7V2.config
@@ -106,7 +106,6 @@ set osd_mah_drawn_pos = 2433
 set osd_craft_name_pos = 2058
 set osd_warnings_pos = 14378
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/HFOR-HIFIONRCF7.config
+++ b/configs/default/HFOR-HIFIONRCF7.config
@@ -105,7 +105,6 @@ set ibata_scale = 450
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/HOWI-HOBBYWING_XROTORF7CONV.config
+++ b/configs/default/HOWI-HOBBYWING_XROTORF7CONV.config
@@ -119,7 +119,6 @@ set ibata_scale = 170
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/IFRC-IFLIGHT_F411_AIO32.config
+++ b/configs/default/IFRC-IFLIGHT_F411_AIO32.config
@@ -105,7 +105,6 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set flash_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/IFRC-IFLIGHT_F722_TWING.config
+++ b/configs/default/IFRC-IFLIGHT_F722_TWING.config
@@ -125,7 +125,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/IFRC-IFLIGHT_SUCCEX_E_F7.config
+++ b/configs/default/IFRC-IFLIGHT_SUCCEX_E_F7.config
@@ -120,7 +120,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/IFRC-JBF7.config
+++ b/configs/default/IFRC-JBF7.config
@@ -172,7 +172,6 @@ set osd_esc_tmp_pos = 82
 set osd_esc_rpm_pos = 83
 set osd_stat_max_spd = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/IFRC-JBF7_DJI.config
+++ b/configs/default/IFRC-JBF7_DJI.config
@@ -149,7 +149,6 @@ set osd_warnings_pos = 2441
 set osd_avg_cell_voltage_pos = 2516
 set osd_disarmed_pos = 2284
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set pinio_config = 129,1,1,1
 set pinio_box = 0,255,255,255
 set flash_spi_bus = 3

--- a/configs/default/JHEF-JHEF411.config
+++ b/configs/default/JHEF-JHEF411.config
@@ -104,7 +104,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/JHEF-JHEF7DUAL.config
+++ b/configs/default/JHEF-JHEF7DUAL.config
@@ -105,7 +105,6 @@ set ibata_scale = 450
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/LDAR-LDARC_F411.config
+++ b/configs/default/LDAR-LDARC_F411.config
@@ -112,7 +112,6 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set flash_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/LMNR-LUXF7HDV.config
+++ b/configs/default/LMNR-LUXF7HDV.config
@@ -84,7 +84,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set esc_sensor_halfduplex = ON
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/LMNR-LUXMINIF7.config
+++ b/configs/default/LMNR-LUXMINIF7.config
@@ -92,7 +92,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set pinio_config = 129,1,1,1
 set pinio_box = 40,255,255,255
 set flash_spi_bus = 2

--- a/configs/default/MERA-MERAKRCF722.config
+++ b/configs/default/MERA-MERAKRCF722.config
@@ -100,7 +100,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 2

--- a/configs/default/MTKS-MATEKF411.config
+++ b/configs/default/MTKS-MATEKF411.config
@@ -110,7 +110,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/MTKS-MATEKF411SE.config
+++ b/configs/default/MTKS-MATEKF411SE.config
@@ -112,7 +112,6 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set pinio_box = 40,255,255,255
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/MTKS-MATEKF722.config
+++ b/configs/default/MTKS-MATEKF722.config
@@ -130,7 +130,6 @@ set beeper_od = OFF
 set sdcard_mode = SPI
 set sdcard_spi_bus = 3
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180

--- a/configs/default/OPEN-REVONANO.config
+++ b/configs/default/OPEN-REVONANO.config
@@ -94,7 +94,6 @@ dma pin A01 0
 set baro_bustype = I2C
 set baro_i2c_device = 3
 set system_hse_mhz = 8
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 2
 set gyro_1_sensor_align = CW270

--- a/configs/default/PYDR-PYRODRONEF7.config
+++ b/configs/default/PYDR-PYRODRONEF7.config
@@ -106,7 +106,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set pid_process_denom = 1
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/RAST-AIRF7.config
+++ b/configs/default/RAST-AIRF7.config
@@ -85,7 +85,6 @@ set beeper_od = OFF
 set max7456_spi_bus = 3
 set pinio_box = 40,255,255,255
 set pinio_config = 129,1,1,1
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/RUSH-BLADE_F7.config
+++ b/configs/default/RUSH-BLADE_F7.config
@@ -114,7 +114,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/RUSH-BLADE_F7_HD.config
+++ b/configs/default/RUSH-BLADE_F7_HD.config
@@ -112,7 +112,6 @@ set battery_meter = ADC
 set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/RUSH-RUSHCORE7.config
+++ b/configs/default/RUSH-RUSHCORE7.config
@@ -100,7 +100,6 @@ set battery_meter = ADC
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270FLIP

--- a/configs/default/SJET-AOCODAF722BLE.config
+++ b/configs/default/SJET-AOCODAF722BLE.config
@@ -103,7 +103,6 @@ set ibata_scale = 166
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 2

--- a/configs/default/SKST-SKYSTARSF411.config
+++ b/configs/default/SKST-SKYSTARSF411.config
@@ -122,7 +122,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180

--- a/configs/default/SPBE-SPEEDYBEEF7.config
+++ b/configs/default/SPBE-SPEEDYBEEF7.config
@@ -132,7 +132,6 @@ set pid_process_denom = 1
 set osd_vbat_pos = 2337
 set osd_altitude_pos = 2305
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/SPRO-SPRACINGF7DUAL.config
+++ b/configs/default/SPRO-SPRACINGF7DUAL.config
@@ -151,7 +151,6 @@ set beeper_od = OFF
 set sdcard_mode = SPI
 set sdcard_spi_bus = 3
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0

--- a/configs/default/STMI-NUCLEOF722.config
+++ b/configs/default/STMI-NUCLEOF722.config
@@ -77,7 +77,6 @@ set mag_bustype = I2C
 set mag_i2c_device = 1
 set baro_bustype = I2C
 set baro_i2c_device = 1
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = I2C
 set gyro_1_i2cBus = 1
 set gyro_1_sensor_align = CW270

--- a/configs/default/STMI-STM32F411DISCOVERY.config
+++ b/configs/default/STMI-STM32F411DISCOVERY.config
@@ -78,7 +78,6 @@ set current_meter = ADC
 set battery_meter = ADC
 set beeper_frequency = 2000
 set system_hse_mhz = 8
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180

--- a/configs/default/TEBS-PODRACERAIO.config
+++ b/configs/default/TEBS-PODRACERAIO.config
@@ -75,7 +75,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW90

--- a/configs/default/TMTR-TMOTORF411.config
+++ b/configs/default/TMTR-TMOTORF411.config
@@ -91,7 +91,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/TMTR-TMOTORF7.config
+++ b/configs/default/TMTR-TMOTORF7.config
@@ -111,7 +111,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set osd_gps_sats_show_hdop = ON
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/TMTR-TMPACERF7.config
+++ b/configs/default/TMTR-TMPACERF7.config
@@ -82,7 +82,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/TMTR-TMVELOXF7.config
+++ b/configs/default/TMTR-TMVELOXF7.config
@@ -128,7 +128,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set pid_process_denom = 4
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI

--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -117,7 +117,6 @@ set osd_current_pos = 2486
 set osd_craft_name_pos = 2112
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set name = TransTEC

--- a/configs/default/TTRH-TRANSTECF7.config
+++ b/configs/default/TTRH-TRANSTECF7.config
@@ -101,7 +101,6 @@ set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180FLIP
 set gyro_2_spibus = 1

--- a/configs/default/TTRH-TRANSTECF7HD.config
+++ b/configs/default/TTRH-TRANSTECF7HD.config
@@ -101,7 +101,6 @@ set current_meter = ADC
 set battery_meter = ADC
 set pid_process_denom = 1
 set max7456_spi_bus = 0
-set dashboard_i2c_bus = 1
 set gyro_1_spibus = 1
 set flash_spi_bus = 2
 set gyro_1_sensor_align = CW180FLIP

--- a/configs/default/VGRC-VGOODF722DUAL.config
+++ b/configs/default/VGRC-VGOODF722DUAL.config
@@ -130,7 +130,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set gps_provider = UBLOX
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/WIZZ-WIZZF7HD.config
+++ b/configs/default/WIZZ-WIZZF7HD.config
@@ -101,7 +101,6 @@ set sdcard_detect_inverted = ON
 set sdcard_mode = SPI
 set sdcard_spi_bus = 2
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_to_use = BOTH

--- a/configs/default/YUPF-YUPIF7.config
+++ b/configs/default/YUPF-YUPIF7.config
@@ -96,7 +96,6 @@ set battery_meter = ADC
 set ibata_scale = 235
 set beeper_frequency = 3150
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/ZEEZ-ZEEZF7V2.config
+++ b/configs/default/ZEEZ-ZEEZF7V2.config
@@ -129,7 +129,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set osd_core_temp_alarm = 85
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 3
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1

--- a/configs/default/ZEEZ-ZEEZWHOOP.config
+++ b/configs/default/ZEEZ-ZEEZWHOOP.config
@@ -73,7 +73,6 @@ set motor_pwm_protocol = DSHOT600
 set battery_meter = ADC
 set system_hse_mhz = 8
 set max7456_spi_bus = 1
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 3
 set gyro_1_sensor_align = CW90


### PR DESCRIPTION
Follow-up to https://github.com/betaflight/betaflight/pull/10415 which removed dashboard support for the STM32F411 and STM32F7X2 Unified Targets to save some flash space.