### PR TITLE
Revert DIAT 466

### DIFF
--- a/configs/default/DIAT-MAMBAF405US.config
+++ b/configs/default/DIAT-MAMBAF405US.config
@@ -90,8 +90,8 @@ resource LED_STRIP 1 B03
 resource CAMERA_CONTROL 1 B08
 
 # DMA
-dma ADC 3 1
-# ADC 3: DMA2 Stream 1 Channel 2
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
 dma pin A09 0
 # pin A09: DMA2 Stream 6 Channel 0
 dma pin A08 0

--- a/configs/default/DIAT-MAMBAF405US_I2C.config
+++ b/configs/default/DIAT-MAMBAF405US_I2C.config
@@ -91,8 +91,8 @@ resource MOTOR 4 C08
 resource LED_STRIP 1 B03
 
 # DMA
-dma ADC 3 1
-# ADC 3: DMA2 Stream 1 Channel 2
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
 dma pin A09 0
 # pin A09: DMA2 Stream 6 Channel 0
 dma pin A08 0

--- a/configs/default/DIAT-MAMBAF722.config
+++ b/configs/default/DIAT-MAMBAF722.config
@@ -87,7 +87,8 @@ resource LED_STRIP 1 B03
 resource CAMERA_CONTROL 1 B08
 
 # dma
-dma ADC 3 1    # ADC 3: DMA2 Stream 1 Channel 2
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0

--- a/configs/default/DIAT-MAMBAF722_I2C.config
+++ b/configs/default/DIAT-MAMBAF722_I2C.config
@@ -89,8 +89,8 @@ resource MOTOR 4 A09
 resource LED_STRIP 1 B03
 
 # dma
-dma ADC 3 1
-# ADC 3: DMA2 Stream 1 Channel 2
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0


### PR DESCRIPTION
Diatone contacted me for emergency change to these.   Boards becoming inoperative due to #466 .

Revert All Diatone 466 changes.  Boards become inoperative once config uploaded.   I am moving right now and everything packed up, but all I can surmise is that the change conflicts with TIM8_UP on Stream 1, locking up the board.  Please change this back ASAP so we can get the boards working again for folks and then figure out what is going on.  Sorry about this.  Should have noticed earlier.   

