### PR TITLE
Fixed MAMBAF722 resource allocation for SPI DMA.

### DIFF
--- a/configs/default/DIAT-MAMBAF722.config
+++ b/configs/default/DIAT-MAMBAF722.config
@@ -87,8 +87,8 @@ resource LED_STRIP 1 B03
 resource CAMERA_CONTROL 1 B08
 
 # dma
-dma ADC 3 0
-# ADC 3: DMA2 Stream 0 Channel 2
+dma ADC 3 1
+# ADC 3: DMA2 Stream 1 Channel 2
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0
@@ -123,8 +123,7 @@ set mag_i2c_device = 1
 set mag_bustype = I2C
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
-set dshot_burst = ON
-set motor_pwm_protocol = DSHOT600
+set dshot_bitbang = ON
 set pinio_box = 0,255,255,255
 set pinio_config = 129,1,1,1
 set current_meter = ADC

--- a/configs/default/DIAT-MAMBAF722_I2C.config
+++ b/configs/default/DIAT-MAMBAF722_I2C.config
@@ -89,8 +89,8 @@ resource MOTOR 4 A09
 resource LED_STRIP 1 B03
 
 # dma
-dma ADC 3 0
-# ADC 3: DMA2 Stream 0 Channel 2
+dma ADC 3 1
+# ADC 3: DMA2 Stream 1 Channel 2
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0
@@ -124,8 +124,7 @@ set mag_bustype = I2C
 set mag_i2c_device = 1
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
-set dshot_burst = ON
-set motor_pwm_protocol = DSHOT600
+set dshot_bitbang = ON
 set pinio_box = 0,255,255,255
 set pinio_config = 129,1,1,1
 set current_meter = ADC


### PR DESCRIPTION
@kc10kevin: Can you test this please? This improves on #478 by making it possible to run the gyro SPI bus with DMA, by enabling bitbanged Dshot by default. (The same is not possible on the MAMBAF405US, as there is a hardware bug in the STM32F4 DMA mux that makes it impossible to use GPIO and SPI DMA on DMA 2 concurrently, and there is no way to drive motor pins 1 - 4 with DMA 1 only.