### PR TITLE
Set the target BETAFPVF411RX dshot_bitbang to OFF

### DIFF
--- a/configs/default/BEFH-BETAFPVF411RX.config
+++ b/configs/default/BEFH-BETAFPVF411RX.config
@@ -85,6 +85,7 @@ set rx_spi_protocol = FRSKY_X
 set rx_spi_bus = 3
 set rx_spi_led_inversion = ON
 set dshot_burst = AUTO
+set dshot_bitbang = OFF
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 179


### PR DESCRIPTION
This modification is to synchronize [betaflight/unified-targets#95](https://github.com/betaflight/unified-targets/pull/95). 

Solve the conflict between use timer dshot and timer1.