### PR TITLE
Remove outdated dashboard setting in HYBRIDG4 target

### DIFF
--- a/configs/default/NERC-HYBRIDG4.config
+++ b/configs/default/NERC-HYBRIDG4.config
@@ -96,7 +96,6 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set led_inversion = 1
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1


### PR DESCRIPTION
G47x now do not have dashboard, I just forgot to remove them when #472 raised.