### PR TITLE
Added BLITZ F405 Target

### DIFF
--- a/configs/default/IFRC-IFLIGHT_BLITZ_F405.config
+++ b/configs/default/IFRC-IFLIGHT_BLITZ_F405.config
@@ -1,0 +1,97 @@
+# Betaflight / STM32F405 (S405) 4.2.9 Apr 27 2021 / 19:33:01 (e097f4ab7) MSP API: 1.43
+
+board_name IFLIGHT_BLITZ_F405 
+manufacturer_id IFRC
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 C09
+resource MOTOR 4 C08
+resource PPM 1 A03
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C15
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ADC_BATT 1 C02
+resource ADC_CURR 1 C01
+resource FLASH_CS 1 A15
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C05
+
+# timer
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 200
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1


### PR DESCRIPTION
Initial commit:
Added F405 target for Iflight BLIZT F405

@mikeller This is iFlight new official Github account for target. 
We would like to be code maintainers for our target from now on. We will also maintain our old target. Please kindly modify the code owner for IFRC if possible.
Should we open an issue for modify the code ownership of IFRC target under this account or can you do it without any action from us?
