### PR TITLE
Revert "Fix dma ADC"

### DIFF
--- a/configs/default/TMTR-TMVELOXF7.config
+++ b/configs/default/TMTR-TMVELOXF7.config
@@ -76,8 +76,8 @@ timer A03 AF2
 # pin A03: TIM5 CH4 (AF2)
 
 # dma
-dma ADC 1 1
-# ADC 1: DMA2 Stream 4 Channel 2
+dma ADC 3 1
+# ADC 3: DMA2 Stream 1 Channel 2
 dma pin C06 0
 # pin C06: DMA2 Stream 2 Channel 0
 dma pin B01 0


### PR DESCRIPTION
Reverts betaflight/unified-targets#508

PR https://github.com/betaflight/betaflight/pull/10895 should fix the issue as test is succesful with stm32f7x2 (using Matek F722Mini config).

This PR should be tested with the following firmware:
[betaflight_4.3.0_STM32F7X2_35e6d3680.zip](https://github.com/betaflight/unified-targets/files/7228509/betaflight_4.3.0_STM32F7X2_35e6d3680.zip)
 Please load the config in this PR before flashing the unified target.