### PR TITLE
Add JHEF-JHEF405PRO

### DIFF
--- a/configs/default/JHEF-JHEF405PRO.config
+++ b/configs/default/JHEF-JHEF405PRO.config
@@ -9,10 +9,6 @@ resource MOTOR 1 B00
 resource MOTOR 2 B01
 resource MOTOR 3 A03
 resource MOTOR 4 A02
-resource MOTOR 5 B05
-resource MOTOR 6 B07
-resource MOTOR 7 C09
-resource MOTOR 8 C08
 resource PPM 1 B08
 resource LED_STRIP 1 A09
 resource SERIAL_TX 1 B06
@@ -53,19 +49,11 @@ timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
 timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
-timer B05 AF2
-# pin B05: TIM3 CH2 (AF2)
-timer B07 AF2
-# pin B07: TIM4 CH2 (AF2)
-timer C09 AF3
-# pin C09: TIM8 CH4 (AF3)
-timer C08 AF3
-# pin C08: TIM8 CH3 (AF3)
 timer A09 AF1
 # pin A09: TIM1 CH2 (AF1)
 
 # dma
-dma ADC 1 0
+dma ADC 1 1
 # ADC 1: DMA2 Stream 0 Channel 0
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
@@ -75,14 +63,6 @@ dma pin A03 1
 # pin A03: DMA1 Stream 6 Channel 3
 dma pin A02 0
 # pin A02: DMA1 Stream 1 Channel 3
-dma pin B05 0
-# pin B05: DMA1 Stream 5 Channel 5
-dma pin B07 0
-# pin B07: DMA1 Stream 3 Channel 2
-dma pin C09 0
-# pin C09: DMA2 Stream 7 Channel 7
-dma pin C08 0
-# pin C08: DMA2 Stream 2 Channel 0
 dma pin A09 0
 # pin A09: DMA2 Stream 6 Channel 0
 

--- a/configs/default/JHEF-JHEF405PRO.config
+++ b/configs/default/JHEF-JHEF405PRO.config
@@ -1,0 +1,113 @@
+# Betaflight / STM32F405 (S405) 4.2.0 Nov 22 2020 / 18:38:23 (afdac08b3) MSP API: 1.43
+
+board_name JHEF405PRO
+manufacturer_id JHEF
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 A03
+resource MOTOR 4 A02
+resource MOTOR 5 B05
+resource MOTOR 6 B07
+resource MOTOR 7 C09
+resource MOTOR 8 C08
+resource PPM 1 B08
+resource LED_STRIP 1 A09
+resource SERIAL_TX 1 B06
+resource SERIAL_TX 2 D05
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 D06
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 B08
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C02
+resource FLASH_CS 1 B03
+resource OSD_CS 1 B14
+resource GYRO_EXTI 1 B13
+resource GYRO_CS 1 B12
+resource USB_DETECT 1 A08
+
+# timer
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer A09 AF1
+# pin A09: TIM1 CH2 (AF1)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin A02 0
+# pin A02: DMA1 Stream 1 Channel 3
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin A09 0
+# pin A09: DMA2 Stream 6 Channel 0
+
+# feature
+feature RX_SERIAL
+feature OSD
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 170
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 3
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
This is a new "PRO" version of the JHEF405, which exposes additional UARTs.

Board can be distinguished from previous non-PRO variants by the 45A ESC on the PRO vs 35A on non-PRO.

Flashed and test-hovered my board using the config here.