### PR TITLE
HGLRC Zeus F722 - fix baro config

### DIFF
--- a/configs/default/HGLR-HGLRCF722.config
+++ b/configs/default/HGLR-HGLRCF722.config
@@ -113,7 +113,8 @@ serial 0 64 115200 57600 0 115200
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1
-set baro_spi_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
 set dshot_burst = ON
 set motor_pwm_protocol = DSHOT600


### PR DESCRIPTION
Baro BMP280 is connected to the I2C bus, not SPI.
This fixes FC hangup (#523).
