### PR TITLE
Add new target NEUTRONRCF407

### DIFF
--- a/configs/default/NERC-NEUTRONRCF407.config
+++ b/configs/default/NERC-NEUTRONRCF407.config
@@ -1,0 +1,120 @@
+# Betaflight / STM32F405 (S405) 4.0.0 Mar 14 2019 / 11:45:26 (360afd96d) MSP API: 1.41
+
+board_name NEUTRONRCF407
+manufacturer_id NERC
+
+# resources
+resource BEEPER 1 B04
+resource MOTOR 1 B00
+resource MOTOR 2 B01
+resource MOTOR 3 C09
+resource MOTOR 4 C08
+resource PPM 1 A03
+resource LED_STRIP 1 B06
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource INVERTER 2 C13
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 B05
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource CAMERA_CONTROL 1 B07
+resource ADC_CURR 1 C01
+resource ADC_BATT 1 C02
+resource FLASH_CS 1 A15
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C05
+
+# timer
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A03 0
+# pin A03: DMA1 Stream 1 Channel 6
+dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 0 8192 115200 57600 0 115200
+serial 1 64 115200 57600 0 115200
+
+# master
+set serialrx_provider = SBUS
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set blackbox_device = SPIFLASH
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_hardware = BMP280
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 100
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270


### PR DESCRIPTION
The chip is STM32F407, we have verified that this can work with F405 unified target. But the only thing not sure is whether we need to not use this "F407" name that might cause potential misunderstand