### PR TITLE
Update GEPR-GEPRCF722BT.config for fix voltage meter display error

### DIFF
--- a/configs/default/GEPR-GEPRCF722BT.config
+++ b/configs/default/GEPR-GEPRCF722BT.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F7X2 (S7X2) 4.2.11 Nov  9 2021 / 20:29:32 (948ba6339) MSP API: 1.43
+# Betaflight / STM32F7X2 (S7X2) 4.1.7 May 28 2020 / 15:06:20 (9ba02a587) MSP API: 1.42
 board_name GEPRCF722BT
 manufacturer_id GEPR
 

--- a/configs/default/GEPR-GEPRCF722BT.config
+++ b/configs/default/GEPR-GEPRCF722BT.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F7X2 (S7X2) 4.1.7 May 28 2020 / 15:06:20 (9ba02a587) MSP API: 1.42
+# Betaflight / STM32F7X2 (S7X2) 4.2.11 Nov  9 2021 / 20:29:32 (948ba6339) MSP API: 1.43
 board_name GEPRCF722BT
 manufacturer_id GEPR
 
@@ -58,8 +58,8 @@ timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
 
 # dma
-dma ADC 3 1
-# ADC 3: DMA2 Stream 1 Channel 2
+dma ADC 3 0
+# ADC 3: DMA2 Stream 0 Channel 2
 dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0
@@ -72,10 +72,11 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
+feature TELEMETRY
+feature LED_STRIP
 feature OSD
-feature gps
+feature GPS
 
 # serial
 serial 1 64 115200 57600 0 115200
@@ -90,14 +91,13 @@ set baro_i2c_device = 1
 set serialrx_provider = SBUS
 set adc_device = 3
 set blackbox_device = SPIFLASH
+set dshot_burst = ON
 set current_meter = ADC
 set battery_meter = ADC
 set beeper_inversion = ON
-set dshot_burst = ON
-set gps_provider = UBLOX
 set max7456_spi_bus = 2
+set pinio_config = 129,1,1,1
+set pinio_box = 0,255,255,255
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
-set pinio_config = 129,1,1,1
-set pinio_box = 0,255,255,255

--- a/configs/default/GEPR-GEPRCF722BT.config
+++ b/configs/default/GEPR-GEPRCF722BT.config
@@ -76,7 +76,6 @@ feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP
 feature OSD
-feature GPS
 
 # serial
 serial 1 64 115200 57600 0 115200


### PR DESCRIPTION
Help GEPRC and (VGOOD made this board) to fix battery  voltage meter display error.
In 4.1 battery voltage meter display correctly, but in 4.2 it broken. They find change the ADC DMA number can fix it.

