### PR TITLE
Fix boot_grace_time flag on flowbox target

### DIFF
--- a/configs/default/NERC-FLOWBOX.config
+++ b/configs/default/NERC-FLOWBOX.config
@@ -5,6 +5,10 @@ manufacturer_id NERC
 
 # resources
 resource BEEPER 1 B01
+resource MOTOR 1 B10
+resource MOTOR 2 A00
+resource MOTOR 3 B06
+resource MOTOR 4 B07
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
 resource SERIAL_RX 1 A10
@@ -19,19 +23,30 @@ resource SPI_MOSI 3 B05
 resource FLASH_CS 1 A15
 resource GYRO_EXTI 1 A01
 resource GYRO_CS 1 A04
-resource PWM 1 B10
 
 # timer
 timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
 timer B10 AF1
 # pin B10: TIM2 CH3 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A00 AF1
+# pin A00: TIM2 CH1 (AF1)
 
 # dma
 dma ADC 1 1
 # ADC 1: DMA2 Stream 4 Channel 0
 dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A00 0
+# pin A00: DMA1 Stream 5 Channel 3
 
 # feature
 feature -RX_PARALLEL_PWM


### PR DESCRIPTION
Added motor settings for flowbox target, confirmed to work. We might make flowbow variants with motor pads anyway in the future, so this is needed.