### PR TITLE
bugfix for 4.3 - set EXTI to none for NOX

### DIFF
--- a/configs/default/AIRB-NOX.config
+++ b/configs/default/AIRB-NOX.config
@@ -29,7 +29,7 @@ resource ADC_BATT 1 A05
 resource BARO_CS 1 A09
 resource FLASH_CS 1 A15
 resource OSD_CS 1 A10
-resource GYRO_EXTI 1 A08
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 B12
 
 # timer


### PR DESCRIPTION
Since firmware PR 10997, Nox boards (not all, but some) have an issue where the gyro abruptly, and randomly, goes nuts.  

It is definitely related to gyro EXTI sync to the CPU, since if we disable EXTI sync, the problem disappears.  This PR applies that fix for 4.3, and is a temporary fix until Steve can figure out exactly why this particular board is affected.

It seems to be related to the way this board shares gyro and OSD on the same SPI bus.