### PR TITLE
disable GYRO_EXTI when Gyro and OSD are on the same SPI bus

### DIFF
--- a/configs/default/AIRB-NOX.config
+++ b/configs/default/AIRB-NOX.config
@@ -29,7 +29,9 @@ resource ADC_BATT 1 A05
 resource BARO_CS 1 A09
 resource FLASH_CS 1 A15
 resource OSD_CS 1 A10
-resource GYRO_EXTI 1 A08
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 A08
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 B12
 
 # timer

--- a/configs/default/AIRB-OMNIBUSF4FW.config
+++ b/configs/default/AIRB-OMNIBUSF4FW.config
@@ -36,7 +36,9 @@ resource ADC_CURR 1 C01
 resource BARO_CS 1 B03
 resource FLASH_CS 1 B12
 resource OSD_CS 1 A15
-resource GYRO_EXTI 1 C04
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 D02
 resource GYRO_CS 2 A04
 

--- a/configs/default/LEGA-KROOZX.config
+++ b/configs/default/LEGA-KROOZX.config
@@ -46,7 +46,9 @@ resource SDCARD_CS 1 A15
 resource SDCARD_DETECT 1 C13
 resource PINIO 1 C05
 resource OSD_CS 1 C04
-resource GYRO_EXTI 1 A04
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 A04
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 B02
 
 # timer

--- a/configs/default/YUPF-YUPIF4.config
+++ b/configs/default/YUPF-YUPIF4.config
@@ -40,7 +40,9 @@ resource ADC_CURR 1 C02
 resource SDCARD_CS 1 A15
 resource SDCARD_DETECT 1 D02
 resource OSD_CS 1 A14
-resource GYRO_EXTI 1 C04
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 A04
 
 # timer

--- a/configs/default/YUPF-YUPIF7.config
+++ b/configs/default/YUPF-YUPIF7.config
@@ -38,7 +38,9 @@ resource ADC_RSSI 1 C00
 resource ADC_CURR 1 C02
 resource FLASH_CS 1 A15
 resource OSD_CS 1 A14
-resource GYRO_EXTI 1 C04
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 A04
 resource USB_DETECT 1 A08
 

--- a/configs/default/ZEEZ-ZEEZWHOOP.config
+++ b/configs/default/ZEEZ-ZEEZWHOOP.config
@@ -25,7 +25,9 @@ resource SPI_MOSI 1 A07
 resource SPI_MOSI 3 B05
 resource ADC_BATT 1 B01
 resource OSD_CS 1 B10
-resource GYRO_EXTI 1 C15
+# disable GYRO_EXTI because Gyro and OSD share the same bus
+# resource GYRO_EXTI 1 C15
+resource GYRO_EXTI 1 NONE
 resource GYRO_CS 1 A15
 
 # timer


### PR DESCRIPTION
I found that the following boards also share the Gyro and OSD on the same SPI bus, and may be vulnerable to the same issue reported in https://github.com/betaflight/betaflight/pull/11141

> LEGA-KROOZX - both on 1
> YUPF-YUPIF4 - both on 1
> YUPF-YUPIF7 - both on 1
> ZEEZ-ZEEZWHOOP - both on 1
> AIRB-NOX - both on 2
> AIRB-OMNIBUSF4F - both on 3

As a safety precaution, this PR disables GYRO_EXTI on those boards.

I include a comment so the reason why is known.