### PR TITLE
Revert "Disable bitbang and burst dshot on HYBRIDG4"

### DIFF
--- a/configs/default/NERC-HYBRIDG4.config
+++ b/configs/default/NERC-HYBRIDG4.config
@@ -91,8 +91,6 @@ serial 2 1024 115200 57600 0 115200
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
-set dshot_burst = OFF
-set dshot_bitbang = OFF
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8


### PR DESCRIPTION
Reverts betaflight/unified-targets#545

As requested in https://github.com/betaflight/betaflight/pull/11158