### PR TITLE
Re-order motor map on NEUTRONRCG4AIO

### DIFF
--- a/configs/default/NERC-NEUTRONRCG4AIO.config
+++ b/configs/default/NERC-NEUTRONRCG4AIO.config
@@ -5,10 +5,10 @@ manufacturer_id NERC
 
 # resources
 resource BEEPER 1 C14
-resource MOTOR 1 B00
-resource MOTOR 2 B01
-resource MOTOR 3 B04
-resource MOTOR 4 B03
+resource MOTOR 1 B01
+resource MOTOR 2 B00
+resource MOTOR 3 B03
+resource MOTOR 4 B04
 resource LED_STRIP 1 A08
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02


### PR DESCRIPTION
Now should work without reorder the motor after flash.