### PR TITLE
config fix MATEKH743

### DIFF
--- a/configs/default/MTKS-MATEKH743.config
+++ b/configs/default/MTKS-MATEKH743.config
@@ -159,12 +159,11 @@ dma pin B09 0
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
-feature LED_STRIP
+feature TELEMETRY
 feature OSD
 
 # serial
 serial 5 64 115200 57600 0 115200
-serial 7 1024 115200 57600 0 115200
 
 # master
 set mag_bustype = I2C


### PR DESCRIPTION
- removed User Settings
- set feature to defaults

@SteveCEvans this reflects the configuration 100% to the legacy target.

@MATEKSYS can you confirm this.