### PR TITLE
removed safety issues on MTKS targets

### DIFF
--- a/configs/default/MTKS-MATEKF405AIO.config
+++ b/configs/default/MTKS-MATEKF405AIO.config
@@ -125,7 +125,6 @@ set baro_hardware = NONE
 set serialrx_provider = SBUS
 set blackbox_device = SDCARD
 set dshot_burst = ON
-set motor_pwm_protocol = DSHOT600
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 165

--- a/configs/default/MTKS-MATEKF405CTR.config
+++ b/configs/default/MTKS-MATEKF405CTR.config
@@ -116,7 +116,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF405MINI.config
+++ b/configs/default/MTKS-MATEKF405MINI.config
@@ -114,7 +114,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF411.config
+++ b/configs/default/MTKS-MATEKF411.config
@@ -96,7 +96,6 @@ serial 0 64 115200 57600 0 115200
 set serialrx_provider = SBUS
 set dshot_burst = AUTO
 set dshot_bitbang = OFF
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF411SE.config
+++ b/configs/default/MTKS-MATEKF411SE.config
@@ -98,7 +98,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF722.config
+++ b/configs/default/MTKS-MATEKF722.config
@@ -114,7 +114,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF722MINI.config
+++ b/configs/default/MTKS-MATEKF722MINI.config
@@ -120,7 +120,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE

--- a/configs/default/MTKS-MATEKF722SE.config
+++ b/configs/default/MTKS-MATEKF722SE.config
@@ -122,7 +122,6 @@ serial 1 64 115200 57600 0 115200
 
 # master
 set serialrx_provider = SBUS
-set motor_pwm_protocol = DSHOT600
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set mag_hardware = NONE


### PR DESCRIPTION
referring to -> https://github.com/betaflight/betaflight/blob/master/docs/TargetMaintenance/CreatingAUnifiedTarget.md#13-donts
> setting `motor_pwm_protocol` to any digital protocol - if this default configuration is used with ESCs that do not support digital protocols, it is likely to result in motors spinning up as soon as a battery is connected. The default of `DISABLED` is safe, and the user will be asked to select a motor protocol that is appropriate for their ESCs when they connect to Betaflight Configurator.

I think the `set motor_pwm_protocol = DSHOT600` should be removed.
