### PR TITLE
FOSS-FENIX_F405 update for dma

### DIFF
--- a/configs/default/FOSS-FENIX_F405.config
+++ b/configs/default/FOSS-FENIX_F405.config
@@ -8,6 +8,7 @@ resource MOTOR 1 B01
 resource MOTOR 2 B00
 resource MOTOR 3 A03
 resource MOTOR 4 A02
+resource LED_STRIP 1 C08
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 3 B10
 resource SERIAL_TX 6 C06
@@ -40,9 +41,11 @@ timer A03 AF1
 # pin A03: TIM2 CH4 (AF1)
 timer A02 AF1
 # pin A02: TIM2 CH3 (AF1)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
 
 # dma
-dma ADC 1 1
+dma ADC 1 0
 # ADC 1: DMA2 Stream 4 Channel 0
 dma pin B01 0
 # pin B01: DMA2 Stream 6 Channel 0
@@ -52,17 +55,22 @@ dma pin A03 1
 # pin A03: DMA1 Stream 6 Channel 3
 dma pin A02 0
 # pin A02: DMA1 Stream 1 Channel 3
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
 
 # feature
 feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
+feature LED_STRIP
 
 # serial
-serial 2 2048 115200 57600 0 115200
 serial 5 64 115200 57600 0 115200
 
 # master
+set serialrx_provider = CRSF
+set dshot_bitbang = OFF
+set motor_pwm_protocol = DSHOT300
 set blackbox_device = SPIFLASH
 set current_meter = ADC
 set battery_meter = ADC


### PR DESCRIPTION
Update to the FOSS-FENIX_F405 target.

- adds LED_STRIP
- corrects dma allocation

```
# dma show

Currently active DMA:
--------------------
DMA1 Stream 0: SPI_MISO 3
DMA1 Stream 1: MOTOR 4
DMA1 Stream 2: FREE
DMA1 Stream 3: SPI_MISO 2
DMA1 Stream 4: SPI_MOSI 2
DMA1 Stream 5: SPI_MOSI 3
DMA1 Stream 6: MOTOR 3
DMA1 Stream 7: MOTOR 2
DMA2 Stream 0: ADC 1
DMA2 Stream 1: FREE
DMA2 Stream 2: SPI_MISO 1
DMA2 Stream 3: SPI_MOSI 1
DMA2 Stream 4: LED_STRIP
DMA2 Stream 5: FREE
DMA2 Stream 6: MOTOR 1
DMA2 Stream 7: FREE
```
