### PR TITLE
Set default compass i2c device

### DIFF
--- a/configs/default/IFRC-IFLIGHT_SUCCEX_E_F4.config
+++ b/configs/default/IFRC-IFLIGHT_SUCCEX_E_F4.config
@@ -86,6 +86,7 @@ set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set baro_bustype = I2C
 set baro_i2c_device = 2
+set mag_i2c_device = 2
 set dshot_burst = ON
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC


### PR DESCRIPTION
There is a single i2c on this board, and all i2c stuff should be mapped here by default