### PR TITLE
Added anyleaf mercury g4

### DIFF
--- a/configs/default/ANYL-MERCURYG4.config
+++ b/configs/default/ANYL-MERCURYG4.config
@@ -1,5 +1,5 @@
 # (todo: What goes on this line?)
-# Betaflight / STM32G431 (SH74) 4.3.0 March 17 2022 / 00:00:00 (ee740d1) MSP API: 1.44
+# Betaflight / STM32G47X (SG47) 4.3.0 March 17 2022 / 00:00:00 (ee740d1) MSP API: 1.44
 
 board_name MERCURYG4
 manufacturer_id ANYL
@@ -24,14 +24,14 @@ set baro_i2c_address = 119
 
 # ELRS receiver
 resource ELRS_BUSY C14
-resource ELRS_DIO A01
+resource ELRS_DIO C13
 resource ELRS_CS C15
 set elrs_device = SPIFLASH
 set elrs_spi_bus = 3
 
 
 # Flash
-resource FLASH_CS 1 C13
+resource FLASH_CS 1 C06
 set blackbox_device = SPIFLASH
 set flash_spi_bus = 2
 
@@ -93,7 +93,7 @@ resource MOTOR 2 A10
 resource MOTOR 3 B00
 resource MOTOR 4 B01
 
-resource BEEPER 1 C06
+resource BEEPER 1 A01
 
 
 # DMA
@@ -113,18 +113,13 @@ dma ADC 2 6  # ADC 2, channel 17 for voltage measurement
 dma ADC 2 7  # ADC 2, channel 12 for current measurement
 
 
-# Feature (# todo??)
+# Feature
 feature RX_SERIAL
 feature TELEMETRY
-feature ELRS  # todo
+feature ELRS 
 
-# serial  # todo?
-#serial 5 64 115200 57600 0 115200
 
 # Master
 set system_hse_mhz = 16
 
 # set mag_hardware = NONE
-#set pinio_box = 40,41,255,255 # ??
-
-

--- a/configs/default/ANYL-MERCURYG4.config
+++ b/configs/default/ANYL-MERCURYG4.config
@@ -122,9 +122,9 @@ feature ELRS  # todo
 #serial 5 64 115200 57600 0 115200
 
 # Master
-set mag_hardware = NONE
+set system_hse_mhz = 16
 
-
+# set mag_hardware = NONE
 #set pinio_box = 40,41,255,255 # ??
 
 

--- a/configs/default/ANYLEAF-MERCURYG4.config
+++ b/configs/default/ANYLEAF-MERCURYG4.config
@@ -2,7 +2,7 @@
 # Betaflight / STM32G431 (SH74) 4.3.0 March 17 2022 / 00:00:00 (ee740d1) MSP API: 1.44
 
 board_name MERCURYG4
-manufacturer_id ANYLEAF
+manufacturer_id ANYL
 
 # Resources
 
@@ -23,11 +23,11 @@ set baro_i2c_address = 119
 
 
 # ELRS receiver
-resource ELRS_SD0 C14
-resource ELRS_RESET A01
+resource ELRS_BUSY C14
+resource ELRS_DIO A01
 resource ELRS_CS C15
 set elrs_device = SPIFLASH
-set elrs_spi_bus = 2
+set elrs_spi_bus = 3
 
 
 # Flash
@@ -78,6 +78,9 @@ resource ADC_CURR 1 B02
 set adc_batt_device = 2  # ADC2_IN17
 set adc_curr_device = 2  # ADC2_IN12
 
+set current_meter = ADC
+set battery_meter = ADC
+
 
 # Timer
 timer A00 AF1    # Tim2 ch1
@@ -103,15 +106,14 @@ dma SPI1RX 1
 
 # Streams 2-5 Motors 1-4 respectively.
 dma TIM2 2 3  # Motor 1: Stream 2. Motor 2: Stream 3
-dma TIM2 2 3  # Motor 1: Stream 2. Motor 2: Stream 3
 dma TIM3 4 5  # Motor 3: Stream 4. Motor 4: Stream 4
 
-# ADC on streams 6 and 7.
+# Streams 6 and 7 for ADC voltage, current measurements.
 dma ADC 2 6  # ADC 2, channel 17 for voltage measurement
 dma ADC 2 7  # ADC 2, channel 12 for current measurement
 
 
-# # Feature (# todo??)
+# Feature (# todo??)
 feature RX_SERIAL
 feature TELEMETRY
 feature ELRS  # todo
@@ -121,8 +123,7 @@ feature ELRS  # todo
 
 # Master
 set mag_hardware = NONE
-set current_meter = ADC
-set battery_meter = ADC
+
 
 #set pinio_box = 40,41,255,255 # ??
 

--- a/configs/default/ANYLEAF-MERCURYG4.config
+++ b/configs/default/ANYLEAF-MERCURYG4.config
@@ -1,0 +1,129 @@
+# (todo: What goes on this line?)
+# Betaflight / STM32G431 (SH74) 4.3.0 March 17 2022 / 00:00:00 (ee740d1) MSP API: 1.44
+
+board_name MERCURYG4
+manufacturer_id ANYLEAF
+
+# Resources
+
+
+# IMU
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 C15
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0FLIP # todo
+set gyro_1_align_pitch = 1800  # todo
+
+
+# Barometer
+set baro_hardware = I2C
+set baro_i2c_device = 2
+set baro_i2c_address = 119
+
+
+# ELRS receiver
+resource ELRS_SD0 C14
+resource ELRS_RESET A01
+resource ELRS_CS C15
+set elrs_device = SPIFLASH
+set elrs_spi_bus = 2
+
+
+# Flash
+resource FLASH_CS 1 C13
+set blackbox_device = SPIFLASH
+set flash_spi_bus = 2
+
+
+# SPI
+resource SPI_SCK 1 A05
+resource SPI_MISO 1 A06
+resource SPI_MOSI 1 A07
+
+resource SPI_SCK 2 B13
+resource SPI_MISO 2 B14
+resource SPI_MOSI 2 B15
+
+resource SPI_SCK 3 B03
+resource SPI_MISO 3 B04
+resource SPI_MOSI 3 B05
+
+
+# I2C
+resource I2C_SCL 1 A15
+resource I2C_SDA 1 B09
+
+resource I2C_SCL 2 A09
+resource I2C_SDA 2 A08
+
+
+# UART
+resource SERIAL_TX 1 B06
+resource SERIAL_RX 1 B07
+
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 2 A03
+
+resource SERIAL_TX 3 B10
+resource SERIAL_RX 3 B11
+
+resource SERIAL_TX 4 C10
+resource SERIAL_RX 4 C11
+
+
+# ADC
+resource ADC_BATT 1 A04
+resource ADC_CURR 1 B02
+set adc_batt_device = 2  # ADC2_IN17
+set adc_curr_device = 2  # ADC2_IN12
+
+
+# Timer
+timer A00 AF1    # Tim2 ch1
+timer A10 AF10    # Tim2 ch4
+timer B00 AF2    # Tim3 ch3
+timer B01 AF2    # Tim3 ch4
+
+resource MOTOR 1 A00
+resource MOTOR 2 A10
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+
+resource BEEPER 1 C06
+
+
+# DMA
+
+# Todo: I don't think this syntax is right.
+
+# Stream 0 for IMU Tx. Stream 1 for IMU Rx.
+dma SPI1TX 0
+dma SPI1RX 1
+
+# Streams 2-5 Motors 1-4 respectively.
+dma TIM2 2 3  # Motor 1: Stream 2. Motor 2: Stream 3
+dma TIM2 2 3  # Motor 1: Stream 2. Motor 2: Stream 3
+dma TIM3 4 5  # Motor 3: Stream 4. Motor 4: Stream 4
+
+# ADC on streams 6 and 7.
+dma ADC 2 6  # ADC 2, channel 17 for voltage measurement
+dma ADC 2 7  # ADC 2, channel 12 for current measurement
+
+
+# # Feature (# todo??)
+feature RX_SERIAL
+feature TELEMETRY
+feature ELRS  # todo
+
+# serial  # todo?
+#serial 5 64 115200 57600 0 115200
+
+# Master
+set mag_hardware = NONE
+set current_meter = ADC
+set battery_meter = ADC
+
+#set pinio_box = 40,41,255,255 # ??
+
+


### PR DESCRIPTION
Draft / WIP. Will not be ready to merge until tested on hardware, which is still in development.

Notes:
- Do any changes need to be made on the main Betaflight repo? Instructions are a bit ambiguous about when you also need a legacy config.
- Uses STM32G4 MCU. G4 is supported on a few existing variants, but isn't listed in [the table here](https://github.com/betaflight/betaflight/blob/master/docs/TargetMaintenance/CreatingAUnifiedTarget.md). The variant used by this (Currently G431) should be very similar on the hardware / firmware-programming level.
- Uses onboard ELRS, via a SX1280 chip connected to SPI. There are a few boards that are advertised as supporting this, but I can't find their configs in this repo to use as an example. (Which in itself is odd!)
- There is most certainly incorrect syntax, eg on the first line, and where indicated by comments, eg for DMA, and related to ELRS.