### PR TITLE
Update ADC_CURR AXFL-AXISFLYINGF7.config

### DIFF
--- a/configs/default/AXFL-AXISFLYINGF7.config
+++ b/configs/default/AXFL-AXISFLYINGF7.config
@@ -37,7 +37,7 @@ resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 B05
 resource CAMERA_CONTROL 1 A08
 resource ADC_BATT 1 C00
-resource ADC_CURR 1 C02
+resource ADC_CURR 1 C01
 resource FLASH_CS 1 C04
 resource OSD_CS 1 C13
 resource GYRO_CS 1 B12


### PR DESCRIPTION
I have the AXISFLYINGF7 target board and the resource for the current sensor does not work with the resorce set at C02