### PR TITLE
New HARC-HAKRCF722MINI target

### DIFF
--- a/configs/default/HARC-HAKRCF722MINI.config
+++ b/configs/default/HARC-HAKRCF722MINI.config
@@ -1,4 +1,4 @@
-# Betaflight / STM32F7X2 (S7X2) 4.1.0 Sep  8 2019 / 01:19:23 (f331cb3dd) MSP API: 1.42
+# Betaflight / STM32F7X2 (S7X2) 4.3.0 Apr  1 2022 / 23:54:49 (7fcf16aad) MSP API: 1.44
 
 board_name HAKRCF722MINI
 manufacturer_id HARC

--- a/configs/default/HARC-HAKRCF722MINI.config
+++ b/configs/default/HARC-HAKRCF722MINI.config
@@ -1,0 +1,144 @@
+# Betaflight / STM32F7X2 (S7X2) 4.1.0 Sep  8 2019 / 01:19:23 (f331cb3dd) MSP API: 1.42
+
+board_name HAKRCF722MINI
+manufacturer_id HARC
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B04
+resource MOTOR 2 B05
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+resource MOTOR 5 A15
+resource MOTOR 6 B03
+resource MOTOR 7 B06
+resource MOTOR 8 B07
+resource PPM 1 A03
+resource PWM 1 A02
+resource PWM 2 A01
+resource PWM 3 A00
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 A14
+resource LED 2 A13
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C01
+resource ADC_EXT 1 A04
+resource PINIO 1 C08
+resource PINIO 2 C09
+resource FLASH_CS 1 D02
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 C03
+resource GYRO_CS 1 B02
+resource GYRO_CS 2 C15
+resource USB_DETECT 1 C14
+
+# timer
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+
+# dma
+dma SPI_TX 3 0
+# SPI_TX 3: DMA1 Stream 5 Channel 0
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A08 2
+# pin A08: DMA2 Stream 3 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set serialrx_provider = SBUS
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set mag_hardware = NONE
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set pinio_box = 40,41,255,255
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180FLIP
+set gyro_1_align_pitch = 1800
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
fixes #10769

betaflight/betaflight#10769

on the hakrc f722 mini board the internal blackbox flash isnt working. The needed commands are:

```bash
resource SDCARD_CS 1 none
resource FLASH_CS 1 D02
set blackbox_device = SPIFLASH
set flash_spi_bus = 3
set sdcard_mode = OFF
save
```

this config fixes that right from the start