### PR TITLE
Update Neutron RCF407 target config

### DIFF
--- a/configs/default/NERC-NEUTRONRCF407.config
+++ b/configs/default/NERC-NEUTRONRCF407.config
@@ -37,10 +37,13 @@ resource SPI_MOSI 3 C12
 resource CAMERA_CONTROL 1 B07
 resource ADC_CURR 1 C01
 resource ADC_BATT 1 C02
+resource PINIO 2 B03
 resource FLASH_CS 1 A15
 resource OSD_CS 1 B12
 resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 A08
 resource GYRO_CS 1 A04
+resource GYRO_CS 2 C03
 resource USB_DETECT 1 C05
 
 # timer
@@ -99,6 +102,7 @@ serial 0 8192 115200 57600 0 115200
 serial 1 64 115200 57600 0 115200
 
 # master
+set gyro_to_use = BOTH
 set serialrx_provider = SBUS
 set mag_bustype = I2C
 set mag_i2c_device = 1
@@ -114,7 +118,11 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
 set dashboard_i2c_bus = 1
+set pinio_config = 129,1,1,1
+set pinio_box = 0,40,41,42
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270
+set gyro_2_bustype = SPI
+set gyro_2_spibus = 1


### PR DESCRIPTION
Add settings for dual gyro and pinio per manufacturer's request.