### PR TITLE
Add RacerStar MINI_H743_HD

### DIFF
--- a/configs/default/RAST-MINI_H743_HD.config
+++ b/configs/default/RAST-MINI_H743_HD.config
@@ -1,0 +1,188 @@
+# Betaflight / STM32H743 (SH74) 4.3.0 Apr 15 2022 / 10:19:04 (9360ab1) MSP API: 1.44
+
+board_name MINI_H743_HD
+manufacturer_id RAST
+
+# resources
+resource BEEPER 1 B03
+resource MOTOR 1 D12
+resource MOTOR 2 D13
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+resource MOTOR 5 C08
+resource MOTOR 6 C09
+resource MOTOR 7 B04
+resource MOTOR 8 B05
+resource PPM 1 A03
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 7 E08
+resource SERIAL_TX 8 E01
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource SERIAL_RX 7 E07
+resource SERIAL_RX 8 E00
+resource I2C_SCL 1 B08
+resource I2C_SCL 2 B10
+resource I2C_SDA 1 B09
+resource I2C_SDA 2 B11
+resource LED 1 E02
+resource LED 2 E03
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_SCK 4 E12
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MISO 4 E13
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource SPI_MOSI 4 E14
+resource CAMERA_CONTROL 1 D09
+resource ADC_BATT 1 C03
+resource ADC_RSSI 1 C05
+resource ADC_CURR 1 C02
+resource ADC_EXT 1 C01
+resource PINIO 1 D09
+resource PINIO 2 D11
+resource FLASH_CS 1 B12
+resource OSD_CS 1 A15
+resource GYRO_EXTI 1 B02
+resource GYRO_EXTI 2 E15
+resource GYRO_CS 1 A04
+resource GYRO_CS 2 E11
+
+# timer
+timer D12 AF2
+# pin D12: TIM4 CH1 (AF2)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer E09 AF1
+# pin E09: TIM1 CH1 (AF1)
+timer E11 AF1
+# pin E11: TIM1 CH2 (AF1)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer E13 AF1
+# pin E13: TIM1 CH3 (AF1)
+timer E14 AF1
+# pin E14: TIM1 CH4 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+timer D13 AF2
+# pin D13: TIM4 CH2 (AF2)
+timer D14 AF2
+# pin D14: TIM4 CH3 (AF2)
+timer D15 AF2
+# pin D15: TIM4 CH4 (AF2)
+timer E05 AF4
+# pin E05: TIM15 CH1 (AF4)
+timer E06 AF4
+# pin E06: TIM15 CH2 (AF4)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+
+# dma
+dma ADC 1 8
+# ADC 1: DMA2 Stream 0 Request 9
+dma ADC 2 9
+# ADC 2: DMA2 Stream 1 Request 10
+dma ADC 3 10
+# ADC 3: DMA2 Stream 2 Request 115
+dma TIMUP 1 0
+# TIMUP 1: DMA1 Stream 0 Request 15
+dma TIMUP 2 0
+# TIMUP 2: DMA1 Stream 0 Request 22
+dma TIMUP 3 0
+# TIMUP 3: DMA1 Stream 0 Request 27
+dma TIMUP 5 0
+# TIMUP 5: DMA1 Stream 0 Request 59
+dma TIMUP 8 4
+# TIMUP 8: DMA1 Stream 4 Request 51
+dma pin D12 6
+# pin D12: DMA1 Stream 6 Request 29
+dma pin A03 1
+# pin A03: DMA1 Stream 1 Request 58
+dma pin C08 0
+# pin C08: DMA1 Stream 0 Request 49
+dma pin B00 0
+# pin B00: DMA1 Stream 0 Request 25
+dma pin B01 1
+# pin B01: DMA1 Stream 1 Request 26
+dma pin E09 0
+# pin E09: DMA1 Stream 0 Request 11
+dma pin E11 0
+# pin E11: DMA1 Stream 0 Request 12
+dma pin B04 4
+# pin B04: DMA1 Stream 4 Request 23
+dma pin B05 5
+# pin B05: DMA1 Stream 5 Request 24
+dma pin E13 6
+# pin E13: DMA1 Stream 6 Request 13
+dma pin E14 7
+# pin E14: DMA1 Stream 7 Request 14
+dma pin A00 2
+# pin A00: DMA1 Stream 2 Request 55
+dma pin A01 4
+# pin A01: DMA1 Stream 4 Request 56
+dma pin A02 0
+# pin A02: DMA1 Stream 0 Request 57
+dma pin D13 7
+# pin D13: DMA1 Stream 7 Request 30
+dma pin D14 12
+# pin D14: DMA2 Stream 4 Request 31
+dma pin E05 0
+# pin E05: DMA1 Stream 0 Request 105
+dma pin A08 14
+# pin A08: DMA2 Stream 6 Request 11
+dma pin A15 0
+# pin A15: DMA1 Stream 0 Request 18
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature TELEMETRY
+feature OSD
+
+# master
+set mag_i2c_device = 2
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 250
+set max7456_spi_bus = 3
+set pinio_box = 40,41,255,255
+set flash_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800
+set gyro_2_spibus = 4
+set gyro_2_sensor_align = CW0FLIP
+set gyro_2_align_pitch = 1800


### PR DESCRIPTION
Adding the [RacerStar board](https://m.racerstar.com/20x20mm-racerstar-mini-h743-hd-3-6s-aio-betaflight-flight-controller-w-or-3a-5a-bec-for-rc-fpv-racing-drone-p-461.html) which has been on the market some time but is shipping with a heavily modified IFLIGHT_H743_AIO configuration. This PR adds the Racerstar MINI_H743-HD properly and allows users to upgrade to 4.3 more easily.

