### PR TITLE
Remove dashboard setting from 512K targets

### DIFF
--- a/configs/default/AXFL-AXISFLYINGF7.config
+++ b/configs/default/AXFL-AXISFLYINGF7.config
@@ -106,7 +106,6 @@ set ibata_scale = 179
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 3
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 1
 set gyro_1_spibus = 2
 set gyro_1_bustype = SPI

--- a/configs/default/GEPR-GEPRCF411_AIO.config
+++ b/configs/default/GEPR-GEPRCF411_AIO.config
@@ -108,7 +108,6 @@ set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set blackbox_device = SPIFLASH
 set flash_spi_bus = 2
-set dashboard_i2c_bus = 1
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_i2cBus = 0

--- a/configs/default/GEPR-GEPRC_F722_AIO.config
+++ b/configs/default/GEPR-GEPRC_F722_AIO.config
@@ -120,7 +120,6 @@ set ibata_scale = 100
 set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/11575

Dashboard was removed in https://github.com/betaflight/betaflight/pull/10713 for targets <= 512K.