### PR TITLE
Fixed ADC's DMA setting not correct problem

### DIFF
--- a/configs/default/NEBD-NBD_INFINITYAIOV2.config
+++ b/configs/default/NEBD-NBD_INFINITYAIOV2.config
@@ -53,6 +53,8 @@ timer D13 AF2
 # pin D13: TIM4 CH2 (AF2)
 
 # dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
 dma pin C06 0
 # pin C06: DMA1 Stream 4 Channel 5
 dma pin C07 0


### PR DESCRIPTION
Hi betaflight team!

We removed DMA setting of ADC 1 at last time, because we think about it's a default setting. It causes the voltage detection working wrong, so we add it back for fixing this problem.

Thank！