### PR TITLE
Modify BETAFPV F722 target

### DIFF
--- a/configs/default/BEFH-BETAFPVF722.config
+++ b/configs/default/BEFH-BETAFPVF722.config
@@ -37,7 +37,6 @@ resource SPI_MISO 3 B04
 resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 B05
-resource CAMERA_CONTROL 1 C08
 resource ADC_BATT 1 C00
 resource ADC_RSSI 1 C02
 resource ADC_CURR 1 C01
@@ -45,7 +44,9 @@ resource FLASH_CS 1 B12
 resource BARO_CS 1 C13
 resource OSD_CS 1 A15
 resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 B02
 resource GYRO_CS 1 A04
+resource GYRO_CS 2 C03
 
 # timer
 
@@ -63,8 +64,6 @@ timer B07 AF2
 # pin B07: TIM4 CH2 (AF2)
 timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer C08 AF3
-# pin C08: TIM8 CH3 (AF3)
 
 # dma
 dma ADC 1 0
@@ -81,8 +80,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
-dma pin C08 0
-# pin C08: DMA2 Stream 4 Channel 7
 dma pin A08 0
 # pin A08: DMA2 Stream 3 Channel 6
 
@@ -100,7 +97,6 @@ set baro_spi_device = 3
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set dshot_idle_value = 450
-set motor_pwm_protocol = OFF
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 450
@@ -112,4 +108,8 @@ set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180
 set gyro_1_align_yaw = 1800
+set gyro_2_bustype = SPI
+set gyro_2_spibus = 1
+set gyro_2_sensor_align = CW180 
+set gyro_2_align_yaw = 1800
 


### PR DESCRIPTION
Hi,all.

I request to modify the BETAFPVF722 target, this includes 3 places.

In order for the BETAFPVF722 target to use the dshot_bitbang function properly, I request to remove the CAMERA_CONTROL setting. In the flight controller that has been released, the CAMERA_CONTROL function has not been designed. In fact, it can complete the CAMERA_CONTROL function in motor5 or 6.

motor_pwm_protocol should use the default settings.

Added dual gyroscope settings.

