### PR TITLE
Remove USB_DETECT resource and add note for CS1/CS2 pin assignment

### DIFF
--- a/configs/default/MTKS-MATEKH743.config
+++ b/configs/default/MTKS-MATEKH743.config
@@ -66,7 +66,10 @@ resource GYRO_EXTI 1 B02
 resource GYRO_EXTI 2 E15
 resource GYRO_CS 1 C15
 resource GYRO_CS 2 E11
-resource USB_DETECT 1 E02
+
+# CS1/CS2 pads for SPI3 connection
+# CS1 D04
+# CS2 E02
 
 # timer
 timer B00 AF2


### PR DESCRIPTION
This config erroneously defines a resource for USB_DETECT. Also the CS1/CS2 pads are not documented for Betaflight, so a comment is added for anybody wishing to use them as per https://github.com/betaflight/betaflight/pull/11549#issuecomment-1133423838