### PR TITLE
Update Aocoda maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,7 +89,7 @@
 /configs/default/PYDR-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/RCTI-* @mikeller-test @betaflight/unified-target-administrators
 /configs/default/RUSH-* @DusKing1 @betaflight/unified-target-administrators
-/configs/default/SJET-* @dlt2018 @betaflight/unified-target-administrators
+/configs/default/SJET-* @aocodarc @betaflight/unified-target-administrators
 /configs/default/SKST-* @hongzhou-zeng @betaflight/unified-target-administrators
 /configs/default/SNMT-* @hongzhou-zeng @betaflight/unified-target-administrators
 /configs/default/SPCM-* @Linjieqiang @betaflight/unified-target-administrators


### PR DESCRIPTION
Unauthorized email used for Aocoda maintainer, updated to use gmail.
@aocodarc 