### PR TITLE
Add manufacturer id for DAKEFPV

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /configs/default/CLRA-* @bnn1044 @betaflight/unified-target-administrators
 /configs/default/CYCL-* @GEME-Cyi @betaflight/unified-target-administrators
 /configs/default/DAFP-* @DMAXYANG @betaflight/unified-target-administrators
+/configs/default/DAKE-* @ThanYangFPV @betaflight/unified-target-administrators
 /configs/default/DALR-* @nyway @betaflight/unified-target-administrators
 /configs/default/DERC-* @DemonRC @betaflight/unified-target-administrators
 /configs/default/DFRA-* @mStrangers @betaflight/unified-target-administrators


### PR DESCRIPTION
Fixes https://github.com/betaflight/unified-targets/issues/595

Manufacturer name : DAKEFPV
Mail : [sals@dakefpv.com](mailto:sals@dakefpv.com)
Website : https://dakefpv.com/