### PR TITLE
Fix KakuteH7V2 blackbox display error.

### DIFF
--- a/configs/default/HBRO-KAKUTEH7V2.config
+++ b/configs/default/HBRO-KAKUTEH7V2.config
@@ -129,6 +129,7 @@ set baro_bustype = I2C
 set baro_i2c_device = 1
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
+set sdcard_mode = OFF
 set current_meter = ADC
 set battery_meter = ADC
 set vbat_scale = 109


### PR DESCRIPTION
parameter sdcard_mode was set to SDIO by default. This will cause the onboard SD card to be displayed on the betaflight configurator.
KakuteH7V2 has no SD card, set sdcard_mode = OFF to fix blackbox display error.

