### PR TITLE
Add Geelang (GEPC) Manufacturer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@
 /configs/default/FLMO-* @cvetaevvitaliy @betaflight/unified-target-administrators
 /configs/default/FOXE-* @Johnsnow-foxeer @betaflight/unified-target-administrators
 /configs/default/GEFP-* @x4FF3 @betaflight/unified-target-administrators
+/configs/default/GEPC-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/GEPR-* @Linjieqiang @betaflight/unified-target-administrators
 /configs/default/GFPV-* @GEME-Cyi @betaflight/unified-target-administrators
 /configs/default/HAMO-* @githubDLG @betaflight/unified-target-administrators


### PR DESCRIPTION
Fixes https://github.com/betaflight/unified-targets/issues/621

|||
| -- | -- |
Manufacturer name | GEELANG
Website | https://www.geelang.com
ID | GEPC