### PR TITLE
Add a new target TUNERCF405

### DIFF
--- a/configs/default/TURC-TUNERCF405.config
+++ b/configs/default/TURC-TUNERCF405.config
@@ -1,0 +1,110 @@
+board_name TUNERCF405
+manufacturer_id TURC
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 B00
+resource MOTOR 2 A08
+resource MOTOR 3 B08
+resource MOTOR 4 A15
+resource MOTOR 5 C09
+resource MOTOR 6 C08
+resource MOTOR 7 C07
+resource MOTOR 8 C06
+resource LED_STRIP 1 B01
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource I2C_SCL 2 B10
+resource I2C_SDA 2 B11
+resource LED 1 B09
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ADC_BATT 1 C00
+resource ADC_CURR 1 C01
+resource FLASH_CS 1 B06
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+
+# timer
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C07 AF2
+# pin C07: TIM3 CH2 (AF2)
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma ADC 3 1
+# ADC 3: DMA2 Stream 1 Channel 2
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C07 0
+# pin C07: DMA1 Stream 5 Channel 5
+dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature OSD
+
+# master
+set serialrx_provider = CRSF
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set motor_pwm_protocol = DSHOT600
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 453
+set beeper_inversion = ON
+set beeper_od = OFF
+set osd_displayport_device = MAX7456
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
We'd like to add TUNERCF405 target file to the unified-targets repo.
This F405 AIO board is integrated with ESC. And the ESCs are pre-flashed with Bluejay.
The reason why we set motor_pwm_protocol = DSHOT600 is that the Bluejay doesn't support PWM.
Much appreciate your help in advance!