### PR TITLE
Update SJET-AOCODAF405.config

### DIFF
--- a/configs/default/SJET-AOCODAF405.config
+++ b/configs/default/SJET-AOCODAF405.config
@@ -1,6 +1,6 @@
 # Betaflight / STM32F405 (S405) 4.2.11 Nov  9 2021 / 20:27:49 (948ba6339) MSP API: 1.43
 
-board_name AOCODARCF4
+board_name AOCODAF405
 manufacturer_id SJET
 
 # resources

--- a/configs/default/SJET-AOCODAF405.config
+++ b/configs/default/SJET-AOCODAF405.config
@@ -1,18 +1,19 @@
-# Betaflight / STM32F405 (S405) 4.2.0 Jun 14 2020 / 03:04:22 (8f2d21460) MSP API: 1.43
+# Betaflight / STM32F405 (S405) 4.2.11 Nov  9 2021 / 20:27:49 (948ba6339) MSP API: 1.43
 
-board_name AOCODAF405
+board_name AOCODARCF4
 manufacturer_id SJET
 
 # resources
-resource BEEPER 1 C13
-resource MOTOR 1 C09
-resource MOTOR 2 C08
-resource MOTOR 3 C07
-resource MOTOR 4 C06
+resource BEEPER 1 B08
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 C08
+resource MOTOR 4 C09
 resource MOTOR 5 A15
 resource MOTOR 6 A08
-resource MOTOR 7 B08
-resource PPM 1 A10
+resource MOTOR 7 B10
+resource MOTOR 8 B11
+resource PPM 1 A03
 resource LED_STRIP 1 B01
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
@@ -26,7 +27,7 @@ resource SERIAL_RX 4 A01
 resource SERIAL_RX 5 D02
 resource I2C_SCL 1 B06
 resource I2C_SDA 1 B07
-resource LED 1 B09
+resource LED 1 C13
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 B03
@@ -36,61 +37,67 @@ resource SPI_MISO 3 B04
 resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 B05
-resource ESCSERIAL 1 D02
+resource ESCSERIAL 1 C11
 resource ADC_BATT 1 C02
 resource ADC_RSSI 1 C03
 resource ADC_CURR 1 C01
-resource PINIO 1 B00
 resource FLASH_CS 1 C00
-resource OSD_CS 1 B10
+resource OSD_CS 1 A13
 resource GYRO_EXTI 1 C04
-resource GYRO_CS 1 B11
+resource GYRO_CS 1 A04
 resource USB_DETECT 1 B12
 
 # timer
-timer A10 AF1
-# pin A10: TIM1 CH3 (AF1)
-timer C09 AF3
-# pin C09: TIM8 CH4 (AF3)
-timer C08 AF3
-# pin C08: TIM8 CH3 (AF3)
-timer C07 AF3
-# pin C07: TIM8 CH2 (AF3)
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
 timer C06 AF3
 # pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
 timer A15 AF1
 # pin A15: TIM2 CH1 (AF1)
 timer A08 AF1
 # pin A08: TIM1 CH1 (AF1)
-timer B08 AF2
-# pin B08: TIM4 CH3 (AF2)
-timer B01 AF1
-# pin B01: TIM1 CH3N (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
 
 # dma
 dma ADC 1 0
 # ADC 1: DMA2 Stream 0 Channel 0
-dma pin A10 0
-# pin A10: DMA2 Stream 6 Channel 0
-dma pin C09 0
-# pin C09: DMA2 Stream 7 Channel 7
-dma pin C08 1
-# pin C08: DMA2 Stream 4 Channel 7
+dma pin A03 0
+# pin A03: DMA1 Stream 1 Channel 6
+dma pin C06 1
+# pin C06: DMA2 Stream 2 Channel 7
 dma pin C07 1
 # pin C07: DMA2 Stream 3 Channel 7
-dma pin C06 0
-# pin C06: DMA2 Stream 2 Channel 0
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
 dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
-dma pin A08 0
-# pin A08: DMA2 Stream 6 Channel 0
-dma pin B08 0
-# pin B08: DMA1 Stream 7 Channel 2
+dma pin A08 1
+# pin A08: DMA2 Stream 1 Channel 6
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin B11 0
+# pin B11: DMA1 Stream 7 Channel 3
 dma pin B01 0
-# pin B01: DMA2 Stream 6 Channel 0
+# pin B01: DMA1 Stream 2 Channel 5
 
 # feature
 feature OSD
+
+# serial
+serial 20 1 115200 57600 0 115200
 
 # master
 set mag_bustype = I2C
@@ -106,9 +113,6 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
-set dashboard_i2c_bus = 1
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
-set gyro_1_sensor_align = CW0FLIP
-set gyro_1_align_pitch = 1800


### PR DESCRIPTION
The old configs can only be used on board aocodaf405 v1.0, and now we have A new board aocodaf405 v1.1.
The new board solves the S7 motor and S8 motor conflict problem.To do this, need to change the CS pins of OSD and gyro.
We're not going to create a new configuration file, so overwrite the old configuration file directly.
Can we do it this way?