### PR TITLE
Cleanup target configurations

### DIFF
--- a/configs/default/AFNG-ALIENFLIGHTF4.config
+++ b/configs/default/AFNG-ALIENFLIGHTF4.config
@@ -111,7 +111,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature MOTOR_STOP
 

--- a/configs/default/AFNG-ALIENFLIGHTNGF7.config
+++ b/configs/default/AFNG-ALIENFLIGHTNGF7.config
@@ -106,7 +106,6 @@ dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature MOTOR_STOP
 feature OSD

--- a/configs/default/AFNG-ALIENFLIGHTNGF7_DUAL.config
+++ b/configs/default/AFNG-ALIENFLIGHTNGF7_DUAL.config
@@ -105,7 +105,6 @@ dma pin B08 0
 # pin B08: DMA1 Stream 7 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature MOTOR_STOP
 feature OSD

--- a/configs/default/AFNG-ALIENFLIGHTNGF7_RX.config
+++ b/configs/default/AFNG-ALIENFLIGHTNGF7_RX.config
@@ -94,7 +94,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SPI
 feature MOTOR_STOP
 feature OSD

--- a/configs/default/AIRB-AIRBOTF4.config
+++ b/configs/default/AIRB-AIRBOTF4.config
@@ -100,7 +100,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # master

--- a/configs/default/AIRB-AIRBOTF4SD.config
+++ b/configs/default/AIRB-AIRBOTF4SD.config
@@ -105,7 +105,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # master

--- a/configs/default/AIRB-AIRBOTF4V2.config
+++ b/configs/default/AIRB-AIRBOTF4V2.config
@@ -70,7 +70,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-AIRBOTF7HDV.config
+++ b/configs/default/AIRB-AIRBOTF7HDV.config
@@ -66,7 +66,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # serial

--- a/configs/default/AIRB-HELSEL_STRIKERF7.config
+++ b/configs/default/AIRB-HELSEL_STRIKERF7.config
@@ -69,7 +69,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 

--- a/configs/default/AIRB-HELSEL_STRIKERF7.config
+++ b/configs/default/AIRB-HELSEL_STRIKERF7.config
@@ -88,4 +88,3 @@ set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW90
 set gyro_1_align_yaw = 900
-set name = StrikerF7

--- a/configs/default/AIRB-NOX.config
+++ b/configs/default/AIRB-NOX.config
@@ -68,7 +68,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature SOFTSERIAL

--- a/configs/default/AIRB-OMNIBUSF4FW.config
+++ b/configs/default/AIRB-OMNIBUSF4FW.config
@@ -103,7 +103,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-OMNIBUSF4NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF4NANOV7.config
@@ -70,7 +70,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-OMNIBUSF4SD.config
+++ b/configs/default/AIRB-OMNIBUSF4SD.config
@@ -116,7 +116,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-OMNIBUSF4V6.config
+++ b/configs/default/AIRB-OMNIBUSF4V6.config
@@ -103,7 +103,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-OMNIBUSF7NANOV7.config
+++ b/configs/default/AIRB-OMNIBUSF7NANOV7.config
@@ -69,7 +69,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/AIRB-OMNINXT4.config
+++ b/configs/default/AIRB-OMNINXT4.config
@@ -129,7 +129,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/BEFH-BETAFPVF405.config
+++ b/configs/default/BEFH-BETAFPVF405.config
@@ -92,7 +92,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature AIRMODE
 feature LED_STRIP

--- a/configs/default/BEFH-BETAFPVF411.config
+++ b/configs/default/BEFH-BETAFPVF411.config
@@ -82,7 +82,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/BEFH-BETAFPVF411RX.config
+++ b/configs/default/BEFH-BETAFPVF411RX.config
@@ -72,7 +72,6 @@ dma pin B10 0
 # pin B10: DMA1 Stream 1 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature SOFTSERIAL
 feature OSD
 feature RX_SPI

--- a/configs/default/BEFH-BETAFPVF722.config
+++ b/configs/default/BEFH-BETAFPVF722.config
@@ -87,7 +87,6 @@ dma pin A08 0
 serial 2 64 115200 57600 0 115200
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/BEFH-BETAFPVH743.config
+++ b/configs/default/BEFH-BETAFPVH743.config
@@ -132,7 +132,6 @@ dma pin D14 11
 # pin D14: DMA2 Stream 3 Request 31
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/CLRA-CLRACINGF7.config
+++ b/configs/default/CLRA-CLRACINGF7.config
@@ -115,7 +115,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/CUST-RUSRACE_F4.config
+++ b/configs/default/CUST-RUSRACE_F4.config
@@ -83,7 +83,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/CUST-RUSRACE_F7.config
+++ b/configs/default/CUST-RUSRACE_F7.config
@@ -82,7 +82,6 @@ dma pin A02 0
 # pin A02: DMA1 Stream 0 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/CUST-SIRMIXALOT.config
+++ b/configs/default/CUST-SIRMIXALOT.config
@@ -74,7 +74,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/CYCL-CYCLONEF405_PRO.config
+++ b/configs/default/CYCL-CYCLONEF405_PRO.config
@@ -97,7 +97,6 @@ dma pin B04 0
 # pin B04: DMA1 Stream 4 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/CYCL-CYCLONEF722_PRO.config
+++ b/configs/default/CYCL-CYCLONEF722_PRO.config
@@ -96,7 +96,6 @@ dma pin B04 0
 # pin B04: DMA1 Stream 4 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/DAFP-DARWINF722HD.config
+++ b/configs/default/DAFP-DARWINF722HD.config
@@ -110,7 +110,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DALR-DALRCF405.config
+++ b/configs/default/DALR-DALRCF405.config
@@ -97,7 +97,6 @@ dma pin A05 0
 # pin A05: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/DALR-DALRCF722DUAL.config
+++ b/configs/default/DALR-DALRCF722DUAL.config
@@ -89,7 +89,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/DFRA-DFR_F722_DUAL_HD.config
+++ b/configs/default/DFRA-DFR_F722_DUAL_HD.config
@@ -100,7 +100,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/DIAT-FURYF4OSD.config
+++ b/configs/default/DIAT-FURYF4OSD.config
@@ -75,7 +75,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/DIAT-MAMBAF405US.config
+++ b/configs/default/DIAT-MAMBAF405US.config
@@ -106,7 +106,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # FEATURE
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/DIAT-MAMBAF405US_I2C.config
+++ b/configs/default/DIAT-MAMBAF405US_I2C.config
@@ -107,7 +107,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # FEATURE
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DIAT-MAMBAF405_2022A.config
+++ b/configs/default/DIAT-MAMBAF405_2022A.config
@@ -87,7 +87,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DIAT-MAMBAF411.config
+++ b/configs/default/DIAT-MAMBAF411.config
@@ -90,7 +90,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # FEATURE
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/DIAT-MAMBAF722.config
+++ b/configs/default/DIAT-MAMBAF722.config
@@ -110,7 +110,6 @@ serial 3 1 19200 57600 0 115200
 resource PINIO 1 B00
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature SOFTSERIAL

--- a/configs/default/DIAT-MAMBAF722_2022A.config
+++ b/configs/default/DIAT-MAMBAF722_2022A.config
@@ -95,7 +95,6 @@ dma pin B04 0
 # pin B04: DMA1 Stream 4 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DIAT-MAMBAF722_I2C.config
+++ b/configs/default/DIAT-MAMBAF722_I2C.config
@@ -112,7 +112,6 @@ serial 3 1 115200 57600 0 115200
 resource PINIO 1 B00
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DIAT-MAMBAF722_X8.config
+++ b/configs/default/DIAT-MAMBAF722_X8.config
@@ -97,7 +97,6 @@ dma pin B04 0
 # pin B04: DMA1 Stream 4 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/DRCL-ELINF405.config
+++ b/configs/default/DRCL-ELINF405.config
@@ -93,7 +93,6 @@ dma pin B07 0
 
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/DRCL-ELINF722.config
+++ b/configs/default/DRCL-ELINF722.config
@@ -92,7 +92,6 @@ dma pin B07 0
 
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/DYST-DYSF44530D.config
+++ b/configs/default/DYST-DYSF44530D.config
@@ -103,7 +103,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature LED_STRIP

--- a/configs/default/EMAX-TINYHAWKF411.config
+++ b/configs/default/EMAX-TINYHAWKF411.config
@@ -80,7 +80,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SPI
 feature OSD
 

--- a/configs/default/EXUA-EXF722DUAL.config
+++ b/configs/default/EXUA-EXF722DUAL.config
@@ -100,7 +100,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/FFPV-FF_RACEPITF7.config
+++ b/configs/default/FFPV-FF_RACEPITF7.config
@@ -67,7 +67,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature MOTOR_STOP
 feature SOFTSERIAL

--- a/configs/default/FFPV-FF_RACEPITF7_MINI.config
+++ b/configs/default/FFPV-FF_RACEPITF7_MINI.config
@@ -67,7 +67,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature MOTOR_STOP
 feature SOFTSERIAL

--- a/configs/default/FLCO-FLYCOLORF7.config
+++ b/configs/default/FLCO-FLYCOLORF7.config
@@ -104,7 +104,6 @@ dma pin A03 1
 # pin A03: DMA1 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature RSSI_ADC

--- a/configs/default/FLCO-FLYCOLORF7_AIO.config
+++ b/configs/default/FLCO-FLYCOLORF7_AIO.config
@@ -104,7 +104,6 @@ dma pin A03 1
 # pin A03: DMA1 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/FLWO-FLYWOOF411_5IN1_AIO.config
+++ b/configs/default/FLWO-FLYWOOF411_5IN1_AIO.config
@@ -81,8 +81,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
-feature -RX_SERIAL
 feature LED_STRIP
 feature OSD
 feature RX_SPI

--- a/configs/default/FOSS-DRONIUSF7.config
+++ b/configs/default/FOSS-DRONIUSF7.config
@@ -75,7 +75,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/FOSS-FENIX_F405.config
+++ b/configs/default/FOSS-FENIX_F405.config
@@ -59,7 +59,6 @@ dma pin C08 1
 # pin C08: DMA2 Stream 4 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature LED_STRIP

--- a/configs/default/FOXE-FOXEERF405.config
+++ b/configs/default/FOXE-FOXEERF405.config
@@ -87,7 +87,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/FOXE-FOXEERF745V2_AIO.config
+++ b/configs/default/FOXE-FOXEERF745V2_AIO.config
@@ -76,7 +76,6 @@ dma pin B05 0
 # pin B05: DMA1 Stream 5 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/FOXE-FOXEERF745_AIO.config
+++ b/configs/default/FOXE-FOXEERF745_AIO.config
@@ -76,7 +76,6 @@ dma pin B05 0
 # pin B05: DMA1 Stream 5 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/FRSK-FRSKYF4.config
+++ b/configs/default/FRSK-FRSKYF4.config
@@ -106,7 +106,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 

--- a/configs/default/GEFP-XILOF4.config
+++ b/configs/default/GEFP-XILOF4.config
@@ -75,7 +75,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature ESC_SENSOR

--- a/configs/default/GEPR-GEPRCF405.config
+++ b/configs/default/GEPR-GEPRCF405.config
@@ -93,7 +93,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/GEPR-GEPRCF411.config
+++ b/configs/default/GEPR-GEPRCF411.config
@@ -78,7 +78,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/GEPR-GEPRCF411_AIO.config
+++ b/configs/default/GEPR-GEPRCF411_AIO.config
@@ -81,7 +81,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/GEPR-GEPRCF722.config
+++ b/configs/default/GEPR-GEPRCF722.config
@@ -90,7 +90,6 @@ dma pin A08 2
 # pin A08: DMA2 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/GEPR-GEPRCF722_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF722_BT_HD.config
@@ -100,7 +100,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 feature TELEMETRY

--- a/configs/default/GEPR-GEPRCF745_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF745_BT_HD.config
@@ -106,7 +106,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 feature TELEMETRY

--- a/configs/default/GEPR-GEPRC_F722_AIO.config
+++ b/configs/default/GEPR-GEPRC_F722_AIO.config
@@ -91,7 +91,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature LED_STRIP

--- a/configs/default/GEPR-GEP_F405_VTX_V3.config
+++ b/configs/default/GEPR-GEP_F405_VTX_V3.config
@@ -111,7 +111,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/GFPV-GEMEF722.config
+++ b/configs/default/GFPV-GEMEF722.config
@@ -76,7 +76,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/HAMO-CRAZYBEEF4DX.config
+++ b/configs/default/HAMO-CRAZYBEEF4DX.config
@@ -74,7 +74,6 @@ dma pin A10 0
 
 # feature
 feature OSD
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # map

--- a/configs/default/HAMO-CRAZYBEEF4DXS.config
+++ b/configs/default/HAMO-CRAZYBEEF4DXS.config
@@ -77,7 +77,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature OSD
 feature RX_SPI
 

--- a/configs/default/HAMO-CRAZYBEEF4FS.config
+++ b/configs/default/HAMO-CRAZYBEEF4FS.config
@@ -79,7 +79,6 @@ dma pin A10 0
 # feature
 feature OSD
 feature RX_SPI
-feature -RX_PARALLEL_PWM
 
 # master
 set dshot_burst = AUTO

--- a/configs/default/HARC-HAKRCF405.config
+++ b/configs/default/HARC-HAKRCF405.config
@@ -83,7 +83,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/HARC-HAKRCF405D.config
+++ b/configs/default/HARC-HAKRCF405D.config
@@ -104,7 +104,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/HARC-HAKRCF722MINI.config
+++ b/configs/default/HARC-HAKRCF722MINI.config
@@ -112,7 +112,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/HBRO-KAKUTEF4.config
+++ b/configs/default/HBRO-KAKUTEF4.config
@@ -79,7 +79,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/HBRO-KAKUTEF4V2.config
+++ b/configs/default/HBRO-KAKUTEF4V2.config
@@ -73,7 +73,6 @@ dma pin C08 0
 # pin C08: DMA2 Stream 2 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/HBRO-KAKUTEF7HDV.config
+++ b/configs/default/HBRO-KAKUTEF7HDV.config
@@ -91,7 +91,6 @@ serial 0 1 115200 57600 0 115200
 serial 5 64 115200 57600 0 115200
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/HBRO-KAKUTEF7MINIV3.config
+++ b/configs/default/HBRO-KAKUTEF7MINIV3.config
@@ -86,7 +86,6 @@ dma pin A08 2
 # pin A08: DMA2 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/HENA-TALONF7DJIHD.config
+++ b/configs/default/HENA-TALONF7DJIHD.config
@@ -115,7 +115,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/HENA-TALONF7FUSION.config
+++ b/configs/default/HENA-TALONF7FUSION.config
@@ -71,7 +71,6 @@ dma pin C09 0               # pin C09: DMA2 Stream 7 Channel 7
 dma pin B01 0               # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/HENA-TALONF7V2.config
+++ b/configs/default/HENA-TALONF7V2.config
@@ -71,7 +71,6 @@ dma pin C09 0           # pin C09: DMA2 Stream 7 Channel 7
 dma pin B01 0           # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/HNEC-NIDICI_F4.config
+++ b/configs/default/HNEC-NIDICI_F4.config
@@ -83,7 +83,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/IFRC-IFLIGHT_BLITZ_F405.config
+++ b/configs/default/IFRC-IFLIGHT_BLITZ_F405.config
@@ -72,7 +72,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/IFRC-IFLIGHT_BLITZ_F411RX.config
+++ b/configs/default/IFRC-IFLIGHT_BLITZ_F411RX.config
@@ -65,7 +65,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature OSD
 feature RX_SPI
 

--- a/configs/default/IFRC-IFLIGHT_BLITZ_F722.config
+++ b/configs/default/IFRC-IFLIGHT_BLITZ_F722.config
@@ -94,7 +94,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/IFRC-IFLIGHT_BLITZ_F7_PRO.config
+++ b/configs/default/IFRC-IFLIGHT_BLITZ_F7_PRO.config
@@ -87,7 +87,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/IFRC-IFLIGHT_F405_AIO.config
+++ b/configs/default/IFRC-IFLIGHT_F405_AIO.config
@@ -76,7 +76,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/IFRC-IFLIGHT_F405_TWING.config
+++ b/configs/default/IFRC-IFLIGHT_F405_TWING.config
@@ -96,7 +96,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 2 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/IFRC-IFLIGHT_F722_TWING.config
+++ b/configs/default/IFRC-IFLIGHT_F722_TWING.config
@@ -100,7 +100,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/IFRC-IFLIGHT_F745_AIO.config
+++ b/configs/default/IFRC-IFLIGHT_F745_AIO.config
@@ -116,7 +116,6 @@ dma pin A03 0
 # pin A03: DMA1 Stream 7 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/IFRC-IFLIGHT_F745_AIO_V2.config
+++ b/configs/default/IFRC-IFLIGHT_F745_AIO_V2.config
@@ -104,7 +104,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 feature TELEMETRY

--- a/configs/default/IFRC-IFLIGHT_H743_AIO_V2.config
+++ b/configs/default/IFRC-IFLIGHT_H743_AIO_V2.config
@@ -118,7 +118,6 @@ dma pin C09 3
 # pin C09: DMA1 Stream 3 Request 50
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature RSSI_ADC

--- a/configs/default/IFRC-IFLIGHT_H7_TWING.config
+++ b/configs/default/IFRC-IFLIGHT_H7_TWING.config
@@ -119,7 +119,6 @@ dma pin C09 7
 # pin C09: DMA1 Stream 7 Request 50
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature RSSI_ADC

--- a/configs/default/IFRC-IFLIGHT_SUCCEX_E_F4.config
+++ b/configs/default/IFRC-IFLIGHT_SUCCEX_E_F4.config
@@ -69,7 +69,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 feature TELEMETRY

--- a/configs/default/IFRC-IFLIGHT_SUCCEX_E_F7.config
+++ b/configs/default/IFRC-IFLIGHT_SUCCEX_E_F7.config
@@ -96,7 +96,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/IFRC-JBF7.config
+++ b/configs/default/IFRC-JBF7.config
@@ -101,7 +101,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature ESC_SENSOR

--- a/configs/default/IFRC-JBF7_DJI.config
+++ b/configs/default/IFRC-JBF7_DJI.config
@@ -101,7 +101,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature ESC_SENSOR

--- a/configs/default/IFRC-JBF7_V2.config
+++ b/configs/default/IFRC-JBF7_V2.config
@@ -98,7 +98,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/LDAR-LDARC_F411.config
+++ b/configs/default/LDAR-LDARC_F411.config
@@ -80,7 +80,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/LMNR-LUXF7HDV.config
+++ b/configs/default/LMNR-LUXF7HDV.config
@@ -66,7 +66,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # serial

--- a/configs/default/LMNR-LUXMINIF7.config
+++ b/configs/default/LMNR-LUXMINIF7.config
@@ -75,7 +75,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/MTKS-MATEKF405AIO.config
+++ b/configs/default/MTKS-MATEKF405AIO.config
@@ -107,7 +107,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF405CTR.config
+++ b/configs/default/MTKS-MATEKF405CTR.config
@@ -105,7 +105,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF405MINI.config
+++ b/configs/default/MTKS-MATEKF405MINI.config
@@ -103,7 +103,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF405SE.config
+++ b/configs/default/MTKS-MATEKF405SE.config
@@ -102,7 +102,6 @@ dma pin A02 0
 # pin A02: DMA1 Stream 0 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF405STD.config
+++ b/configs/default/MTKS-MATEKF405STD.config
@@ -110,7 +110,6 @@ dma pin A03 0
 # pin A03: DMA1 Stream 1 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF405TE.config
+++ b/configs/default/MTKS-MATEKF405TE.config
@@ -110,7 +110,6 @@ dma pin A02 0
 # pin A02: DMA1 Stream 0 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF411.config
+++ b/configs/default/MTKS-MATEKF411.config
@@ -80,7 +80,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/MTKS-MATEKF411RX.config
+++ b/configs/default/MTKS-MATEKF411RX.config
@@ -80,7 +80,6 @@ dma pin A10 0
 # pin A10: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SPI
 feature OSD
 

--- a/configs/default/MTKS-MATEKF411SE.config
+++ b/configs/default/MTKS-MATEKF411SE.config
@@ -84,7 +84,6 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/MTKS-MATEKF722.config
+++ b/configs/default/MTKS-MATEKF722.config
@@ -104,7 +104,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF722HD.config
+++ b/configs/default/MTKS-MATEKF722HD.config
@@ -111,7 +111,6 @@ dma pin A02 0
 # pin A02: DMA1 Stream 0 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF722MINI.config
+++ b/configs/default/MTKS-MATEKF722MINI.config
@@ -110,7 +110,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKF722SE.config
+++ b/configs/default/MTKS-MATEKF722SE.config
@@ -112,7 +112,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/MTKS-MATEKH743.config
+++ b/configs/default/MTKS-MATEKH743.config
@@ -160,7 +160,6 @@ dma pin B09 0
 # pin B09: DMA1 Stream 0 Request 111
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/NEBD-NBD_CRICKETF7.config
+++ b/configs/default/NEBD-NBD_CRICKETF7.config
@@ -64,7 +64,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/NEBD-NBD_INFINITYAIO.config
+++ b/configs/default/NEBD-NBD_INFINITYAIO.config
@@ -56,7 +56,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 #feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/NEBD-NBD_INFINITYAIOV2.config
+++ b/configs/default/NEBD-NBD_INFINITYAIOV2.config
@@ -69,7 +69,6 @@ dma pin D13 0
 # pin D13: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/NEBD-NBD_INFINITYF4.config
+++ b/configs/default/NEBD-NBD_INFINITYF4.config
@@ -76,7 +76,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/NEBD-NBD_INFINITYF4.config
+++ b/configs/default/NEBD-NBD_INFINITYF4.config
@@ -115,4 +115,3 @@ set gyro_1_sensor_align = CW90
 set gyro_1_align_yaw = 900
 set pinio_config = 129,1,1,1
 set pinio_box = 40,255,255,255
-set name = INFINITY

--- a/configs/default/NERC-FLOWBOX.config
+++ b/configs/default/NERC-FLOWBOX.config
@@ -51,7 +51,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature -AIRMODE
 feature RX_SERIAL
 

--- a/configs/default/NERC-NEUTRONRCF407.config
+++ b/configs/default/NERC-NEUTRONRCF407.config
@@ -91,7 +91,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/NERC-NEUTRONRCF7AIO.config
+++ b/configs/default/NERC-NEUTRONRCF7AIO.config
@@ -104,7 +104,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/OPEN-REVO.config
+++ b/configs/default/OPEN-REVO.config
@@ -97,7 +97,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 
 # master

--- a/configs/default/PYDR-PYRODRONEF7.config
+++ b/configs/default/PYDR-PYRODRONEF7.config
@@ -84,7 +84,6 @@ dma pin C08 0   # pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0   # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/RAST-MINI_H743_HD.config
+++ b/configs/default/RAST-MINI_H743_HD.config
@@ -161,7 +161,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 0 Request 18
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/RCTI-ARESF7.config
+++ b/configs/default/RCTI-ARESF7.config
@@ -79,7 +79,6 @@ dma pin C09 0
 # pin C09: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/RCTI-ARESF7.config
+++ b/configs/default/RCTI-ARESF7.config
@@ -106,4 +106,3 @@ set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW180
 set gyro_1_align_yaw = 1800
-set name = Ares F7

--- a/configs/default/RUSH-BLADE_F7.config
+++ b/configs/default/RUSH-BLADE_F7.config
@@ -91,7 +91,6 @@ dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature ESC_SENSOR

--- a/configs/default/RUSH-BLADE_F7_HD.config
+++ b/configs/default/RUSH-BLADE_F7_HD.config
@@ -87,7 +87,6 @@ dma pin B07 0
 
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature ESC_SENSOR

--- a/configs/default/SJET-AOCODAF722MINI.config
+++ b/configs/default/SJET-AOCODAF722MINI.config
@@ -88,7 +88,6 @@ dma pin A08 2
 # pin A08: DMA2 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/SJET-AOCODARCH7DUAL.config
+++ b/configs/default/SJET-AOCODARCH7DUAL.config
@@ -133,7 +133,6 @@ dma pin A08 14
 # pin A08: DMA2 Stream 6 Request 11
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/SKST-SKYSTARSF405.config
+++ b/configs/default/SKST-SKYSTARSF405.config
@@ -92,7 +92,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/SKST-SKYSTARSF411.config
+++ b/configs/default/SKST-SKYSTARSF411.config
@@ -94,7 +94,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature TELEMETRY

--- a/configs/default/SKST-SKYSTARSF7HD.config
+++ b/configs/default/SKST-SKYSTARSF7HD.config
@@ -81,7 +81,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature SOFTSERIAL

--- a/configs/default/SKST-SKYSTARSF7HDPRO.config
+++ b/configs/default/SKST-SKYSTARSF7HDPRO.config
@@ -84,7 +84,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/SKST-SKYSTARSH7HD.config
+++ b/configs/default/SKST-SKYSTARSH7HD.config
@@ -155,7 +155,6 @@ dma pin B09 0
 # pin B09: DMA1 Stream 0 Request 111
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/SPBE-SPEEDYBEEF7.config
+++ b/configs/default/SPBE-SPEEDYBEEF7.config
@@ -135,23 +135,3 @@ set max7456_spi_bus = 2
 set flash_spi_bus = 3
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
-
-profile 0
-
-profile 1
-
-profile 2
-
-rateprofile 0
-
-rateprofile 1
-
-rateprofile 2
-
-rateprofile 3
-
-rateprofile 4
-
-rateprofile 5
-
-# 

--- a/configs/default/SPBE-SPEEDYBEEF7.config
+++ b/configs/default/SPBE-SPEEDYBEEF7.config
@@ -97,7 +97,6 @@ dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature SOFTSERIAL
 feature OSD

--- a/configs/default/SPBE-SPEEDYBEEF7MINI.config
+++ b/configs/default/SPBE-SPEEDYBEEF7MINI.config
@@ -108,7 +108,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/SPBE-SPEEDYBEEF7V2.config
+++ b/configs/default/SPBE-SPEEDYBEEF7V2.config
@@ -82,7 +82,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/TCMM-TCMMF411.config
+++ b/configs/default/TCMM-TCMMF411.config
@@ -73,7 +73,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 feature LED_STRIP

--- a/configs/default/TCMM-TCMMF7.config
+++ b/configs/default/TCMM-TCMMF7.config
@@ -112,7 +112,6 @@ dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature OSD

--- a/configs/default/TEBS-PODRACERAIO.config
+++ b/configs/default/TEBS-PODRACERAIO.config
@@ -59,7 +59,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/TMTR-TMOTORF411.config
+++ b/configs/default/TMTR-TMOTORF411.config
@@ -65,7 +65,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/TMTR-TMOTORF722SE.config
+++ b/configs/default/TMTR-TMOTORF722SE.config
@@ -115,7 +115,6 @@ dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/TMTR-TMOTORF7V2.config
+++ b/configs/default/TMTR-TMOTORF7V2.config
@@ -101,7 +101,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/TMTR-TMVELOXF7.config
+++ b/configs/default/TMTR-TMVELOXF7.config
@@ -104,7 +104,6 @@ dma pin A03 1
 # pin A03: DMA1 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature TELEMETRY
 feature LED_STRIP

--- a/configs/default/TTRH-TRANSTECF405HD.config
+++ b/configs/default/TTRH-TRANSTECF405HD.config
@@ -105,4 +105,3 @@ set system_hse_mhz = 8
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set max7456_spi_bus = 0
-set name = TransTEC

--- a/configs/default/TTRH-TRANSTECF405HD.config
+++ b/configs/default/TTRH-TRANSTECF405HD.config
@@ -60,7 +60,6 @@ dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/TTRH-TRANSTECF411.config
+++ b/configs/default/TTRH-TRANSTECF411.config
@@ -54,7 +54,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -119,4 +119,3 @@ set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
-set name = TransTEC

--- a/configs/default/TTRH-TRANSTECF411AIO.config
+++ b/configs/default/TTRH-TRANSTECF411AIO.config
@@ -78,7 +78,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/TTRH-TRANSTECF411HD.config
+++ b/configs/default/TTRH-TRANSTECF411HD.config
@@ -55,7 +55,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 

--- a/configs/default/TTRH-TRANSTECF411HD.config
+++ b/configs/default/TTRH-TRANSTECF411HD.config
@@ -107,12 +107,3 @@ set gyro_1_sensor_align = CW90
 set gyro_1_align_yaw = 900
 set max7456_spi_bus = 0
 set sbus_baud_fast = OFF
-set name = TransTEC
-
-# rateprofile 0
-set roll_rc_rate = 90
-set pitch_rc_rate = 90
-set yaw_rc_rate = 80
-set roll_srate = 65
-set pitch_srate = 65
-set yaw_srate = 60

--- a/configs/default/TTRH-TRANSTECF7.config
+++ b/configs/default/TTRH-TRANSTECF7.config
@@ -81,7 +81,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/TTRH-TRANSTECF7HD.config
+++ b/configs/default/TTRH-TRANSTECF7HD.config
@@ -80,7 +80,6 @@ dma pin A15 0
 # pin A15: DMA1 Stream 5 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/TTRH-TRANSTECF7HD.config
+++ b/configs/default/TTRH-TRANSTECF7HD.config
@@ -106,4 +106,3 @@ set flash_spi_bus = 2
 set gyro_1_sensor_align = CW180FLIP
 set gyro_1_align_pitch = 1800
 set gyro_1_align_yaw = 1800
-set name = TransTEC

--- a/configs/default/TURC-FPVCYCLEF401.config
+++ b/configs/default/TURC-FPVCYCLEF401.config
@@ -56,7 +56,6 @@ dma pin A02 0
 # pin A02: DMA1 Stream 0 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/TURC-TUNERCF405.config
+++ b/configs/default/TURC-TUNERCF405.config
@@ -88,7 +88,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/VGRC-VGOODF722DUAL.config
+++ b/configs/default/VGRC-VGOODF722DUAL.config
@@ -90,7 +90,6 @@ dma pin A08 2
 # pin A08: DMA2 Stream 3 Channel 6
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature GPS
 feature LED_STRIP

--- a/configs/default/VGRC-VGOODRCF4.config
+++ b/configs/default/VGRC-VGOODRCF4.config
@@ -93,7 +93,6 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/VGRC-VGOODRCF405_DJI.config
+++ b/configs/default/VGRC-VGOODRCF405_DJI.config
@@ -79,7 +79,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/VGRC-VGOODRCF722_DJI.config
+++ b/configs/default/VGRC-VGOODRCF722_DJI.config
@@ -77,7 +77,6 @@ dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 

--- a/configs/default/ZEEZ-ZEEZF7.config
+++ b/configs/default/ZEEZ-ZEEZF7.config
@@ -78,7 +78,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/ZEEZ-ZEEZF7V2.config
+++ b/configs/default/ZEEZ-ZEEZF7V2.config
@@ -92,7 +92,6 @@ dma pin B00 0
 # pin B00: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature LED_STRIP
 feature OSD

--- a/configs/default/ZEEZ-ZEEZWHOOP.config
+++ b/configs/default/ZEEZ-ZEEZWHOOP.config
@@ -59,7 +59,6 @@ dma pin A08 0
 # pin A08: DMA2 Stream 6 Channel 0
 
 # feature
-feature -RX_PARALLEL_PWM
 feature RX_SERIAL
 feature OSD
 


### PR DESCRIPTION
Cleaning up some settings:

- set name
- feature -RX_PARALLEL_PWM is already mutual exclusive handled in firmware config.c