### PR TITLE
Update HGLR-HGLRCF722 Baro

### DIFF
--- a/configs/default/HGLR-HGLRCF722.config
+++ b/configs/default/HGLR-HGLRCF722.config
@@ -113,7 +113,8 @@ serial 0 64 115200 57600 0 115200
 # master
 set mag_bustype = I2C
 set mag_i2c_device = 1
-set baro_spi_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
 set blackbox_device = SPIFLASH
 set dshot_burst = ON
 set motor_pwm_protocol = DSHOT600


### PR DESCRIPTION

In the past, because of a certain version, baro could not work properly using SPI, so we have made changes. Currently, the new version of FC baro will use I2C to work, and we will do related after-sales work for the past FC. So hope to pass as soon as possible.