### PR TITLE
Fix 10V BEC PINIO issue on LUXAIO

### DIFF
--- a/configs/default/LMNR-LUXAIO.config
+++ b/configs/default/LMNR-LUXAIO.config
@@ -32,6 +32,7 @@ resource SPI_MOSI 1 A07
 resource SPI_MOSI 2 B15
 resource SPI_MOSI 3 B05
 resource CAMERA_CONTROL 1 A08
+resource ADC_BATT 1 C00
 resource ADC_CURR 1 C01
 resource PINIO 2 B11
 resource FLASH_CS 1 A03
@@ -90,3 +91,5 @@ set gyro_1_spibus = 2
 set gyro_1_sensor_align = CW90FLIP
 set gyro_1_align_pitch = 1800
 set gyro_1_align_yaw = 900
+set pinio_config = 1,129,1,1
+set pinio_box = 255,40,255,255


### PR DESCRIPTION
After updating my Lumenier LUX AIO to Betaflight 4.3.1, the 10V BEC stopped working. After some experimentation (and flashing the original firmware back to the board), I figured out that `PINIO 2` controls the 10V BEC. It needs to be set to inverted output-push-pull then mapped to the USER1 mode. The original firmware also had the `ADC_BATT 1` resource mapped to `C00`.