### PR TITLE
TBS PODRACER AIO - Remove non-existent SERIAL_RX 1 resource.

### DIFF
--- a/configs/default/TEBS-PODRACERAIO.config
+++ b/configs/default/TEBS-PODRACERAIO.config
@@ -13,7 +13,6 @@ resource PPM 1 A03
 resource LED_STRIP 1 A08
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
-resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
 resource I2C_SCL 1 B08
 resource I2C_SDA 1 B09


### PR DESCRIPTION
Removes non available resource.

See: https://github.com/betaflight/unified-targets/commit/64d751c2db1ec584a8ecf475c4d175e633a55cfb#r81814773