### PR TITLE
Rename and add AOCODAF4 targets

### DIFF
--- a/configs/default/SJET-AOCODAF405V2MPU6000.config
+++ b/configs/default/SJET-AOCODAF405V2MPU6000.config
@@ -1,0 +1,125 @@
+# Betaflight / STM32F405 (S405) 4.2.11 Nov  9 2021 / 20:27:49 (948ba6339) MSP API: 1.43
+
+#define USE_BARO_BMP280
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
+
+board_name AOCODAF405V2MPU6000
+manufacturer_id SJET
+
+# resources
+resource BEEPER 1 B08
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 C08
+resource MOTOR 4 C09
+resource MOTOR 5 A15
+resource MOTOR 6 A08
+resource MOTOR 7 B10
+resource MOTOR 8 B11
+resource PPM 1 A03
+resource LED_STRIP 1 B01
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 C13
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ESCSERIAL 1 C11
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C03
+resource ADC_CURR 1 C01
+resource FLASH_CS 1 C00
+resource OSD_CS 1 A13
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 B12
+
+# timer
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin A03 0
+# pin A03: DMA1 Stream 1 Channel 6
+dma pin C06 1
+# pin C06: DMA2 Stream 2 Channel 7
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin A08 1
+# pin A08: DMA2 Stream 1 Channel 6
+dma pin B10 0
+# pin B10: DMA1 Stream 1 Channel 3
+dma pin B11 0
+# pin B11: DMA1 Stream 7 Channel 3
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+
+# feature
+feature TELEMETRY
+feature RX_SERIAL
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 500
+set beeper_inversion = ON
+set beeper_od = OFF
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270

--- a/configs/default/SJET-AOCODAF405V2MPU6500.config
+++ b/configs/default/SJET-AOCODAF405V2MPU6500.config
@@ -1,6 +1,10 @@
 # Betaflight / STM32F405 (S405) 4.2.11 Nov  9 2021 / 20:27:49 (948ba6339) MSP API: 1.43
 
-board_name AOCODAF405V2
+#define USE_BARO_BMP280
+#define USE_GYRO_SPI_MPU6500
+#define USE_ACC_SPI_MPU6500
+
+board_name AOCODAF405V2MPU6500
 manufacturer_id SJET
 
 # resources
@@ -94,6 +98,7 @@ dma pin B01 0
 # pin B01: DMA1 Stream 2 Channel 5
 
 # feature
+feature TELEMETRY
 feature RX_SERIAL
 feature OSD
 


### PR DESCRIPTION
I have this FC but there was not target for it. I saved a dump and diff and compared it to the V2 target. It's almost the same, only the gyro alignment was different so that's why I'm making this PR. Now it's working perfectly.
@aocodarc please check this.

Edit: I talked to the manufacturer and it turned out that there a 2 revisions of the board. One is equipped with mpu6500, the other is mpu6000 but the gyro alignment is different so I get the permission from the manufacturer to rename the original V2 to V2MPU6500 and make a new target for the MPU6000.
The original V2 target is designed for the MPU6500 and V1.1 board which hopefully will be renamed to V2 according to the manufacturer.