### PR TITLE
Fix adc missing problem on NeutronRCF722AIO

### DIFF
--- a/configs/default/NERC-NEUTRONRCF722AIO.config
+++ b/configs/default/NERC-NEUTRONRCF722AIO.config
@@ -104,6 +104,7 @@ set mag_i2c_device = 2
 set baro_bustype = I2C
 set baro_i2c_device = 2
 set serialrx_provider = SBUS
+set adc_device = 3
 set blackbox_device = SPIFLASH
 set dshot_bidir = ON
 set motor_pwm_protocol = DSHOT600


### PR DESCRIPTION
`set adc_device = 3` is missing...