### PR TITLE
SPEEDYBEEF405V3-Fix SPI2 DMA channel unallocated problem

### DIFF
--- a/configs/default/SPBE-SPEEDYBEEF405V3.config
+++ b/configs/default/SPBE-SPEEDYBEEF405V3.config
@@ -13,8 +13,8 @@ resource MOTOR 5 B00
 resource MOTOR 6 B01
 resource MOTOR 7 B05
 resource MOTOR 8 B04
+resource SERVO 1 A08
 resource PPM 1 A03
-resource PWM 1 A08
 resource LED_STRIP 1 C09
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
@@ -74,6 +74,10 @@ timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
 
 # dma
+dma SPI_MOSI 2 0
+# SPI_MOSI 2: DMA1 Stream 4 Channel 0
+dma SPI_TX 2 0
+# SPI_TX 2: DMA1 Stream 4 Channel 0
 dma ADC 1 0
 # ADC 1: DMA2 Stream 0 Channel 0
 dma pin B06 0


### PR DESCRIPTION
1. Fix SPI2 DMA channel unallocated problem
2. Change A08 to servo output
thanks for your review.