### PR TITLE
Bug fixes

### DIFF
--- a/configs/default/TMTR-TMOTORF722SE.config
+++ b/configs/default/TMTR-TMOTORF722SE.config
@@ -46,7 +46,6 @@ resource ADC_CURR 1 C01
 resource ADC_EXT 1 A04
 resource FLASH_CS 1 D02
 resource PINIO 1 C08
-resource CAMERA_CONTROL 1  C09
 resource OSD_CS 1 B12
 resource GYRO_EXTI 1 C04
 resource GYRO_EXTI 2 C03
@@ -81,8 +80,7 @@ timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
 timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
-timer C09 AF3
-# pin C09: TIM8 CH4 (AF3)
+
 
 # dma
 dma SPI_TX 3 0
@@ -111,8 +109,7 @@ dma pin A01 0
 # pin A01: DMA1 Stream 4 Channel 6
 dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
-dma pin C09 0
-# pin C09: DMA2 Stream 7 Channel 7
+
 
 # feature
 feature RX_SERIAL


### PR DESCRIPTION
When two-way DSHOT is used, a timer conflict is prompted, To reduce the use of TIMER,  So cancel camera_ Control function.



