### PR TITLE
Adding defines option for cloud build system.

### DIFF
--- a/configs/default/BKMN-NERO.config
+++ b/configs/default/BKMN-NERO.config
@@ -1,49 +1,48 @@
 # Betaflight / STM32F7X2 (S7X2) 4.0.0
 
+# this will trigger the cloud build system to include these target defines.
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+
 board_name NERO
 manufacturer_id BKMN
-
-defaults nosave
 
 # Basic I/O
 resource LED 1 B06
 resource LED 2 B05
 resource LED 3 B04
 resource beeper C1
-set beeper_inversion = ON
-set beeper_od = OFF
-
-# Buses
 resource I2C_SCL 1 B08
 resource I2C_SDA 1 B09
-
 resource SPI_SCK 1 A05
 resource SPI_MISO 1 A06
 resource SPI_MOSI 1 A07
-
 resource SPI_SCK 2 B13
 resource SPI_MISO 2 B14
 resource SPI_MOSI 2 B15
-
 resource SPI_SCK 3 C10
 resource SPI_MISO 3 C11
 resource SPI_MOSI 3 C12
-
-# Acc/gyro
 resource gyro_cs 1 C4
 resource GYRO_EXTI 1 B15
-set gyro_1_bustype = SPI
-set gyro_1_spibus = 1
-set gyro_1_sensor_align = CW0
-#set gyro_1_hardware = MPU6500 # Not working (yet ... will it ever?)
-
-# SDCard
 resource SDCARD_CS 1 A15
 resource SDCARD_DETECT 1 D02
-set sdcard_detect_inverted = ON
-set sdcard_mode = SPI
-set sdcard_spi_bus = 3
-#dma SPI_TX 3 0
+resource MOTOR 1 A0
+resource MOTOR 2 A1
+resource MOTOR 3 A2
+resource MOTOR 4 A3
+resource LED_STRIP B0
+resource PPM C7
+resource SERIAL_TX 1 A9
+resource SERIAL_RX 1 A10
+resource SERIAL_TX 3 B10
+resource SERIAL_RX 3 B11
+resource SERIAL_TX 6 C6
+resource SERIAL_RX 6 C7
+resource ADC_BATT 1 C03
+resource ESCSERIAL 1 C07
+resource SDCARD_CS 1 A15
+resource SDCARD_DETECT 1 D02
 
 # Timers
 # First four timers
@@ -66,43 +65,43 @@ timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
 timer C09 AF3
 # pin C09: TIM8 CH4 (AF3)
-resource MOTOR 1 A0
-resource MOTOR 2 A1
-resource MOTOR 3 A2
-resource MOTOR 4 A3
 
-# DMA stream conflict if burst mode is not used
-# XXX Need a mechanism to specify dma
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A08 2
+# pin A08: DMA2 Stream 3 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+
+feature RX_SERIAL
+
 set dshot_burst = ON
-
-# Remaining timers
-resource LED_STRIP B0
-resource PPM C7
-
-# Serial ports
-
-resource SERIAL_TX 1 A9
-resource SERIAL_RX 1 A10
-
-resource SERIAL_TX 3 B10
-resource SERIAL_RX 3 B11
-
-resource SERIAL_TX 6 C6
-resource SERIAL_RX 6 C7
-
-# ADC
-
-resource ADC_BATT 1 C03
-
-# Remaining
-
-resource ESCSERIAL 1 C07
-resource SDCARD_CS 1 A15
-resource SDCARD_DETECT 1 D02
-
-# Some configs
-
-FEATURE RX_SERIAL
-set serialrx_provider = SBUS
+set beeper_inversion = ON
+set beeper_od = OFF
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0
+set sdcard_detect_inverted = ON
+set sdcard_mode = SPI
+set sdcard_spi_bus = 3
 serial 5 64 115200 57600 0 115200
 set battery_meter = ADC


### PR DESCRIPTION
The cloud build system will pickup these "comments" and add them as defines. This will allow for a simple way of specifying specific defines on a per target basis for cloud build.

The comment (and standard define structure) allows for backward compatibility
