### PR TITLE
Add UART7_TX resource to JHEF745

### DIFF
--- a/configs/default/JHEF-JHEF745.config
+++ b/configs/default/JHEF-JHEF745.config
@@ -24,6 +24,7 @@ resource SERIAL_RX 3 B11
 resource SERIAL_RX 4 A01
 resource SERIAL_RX 6 C07
 resource SERIAL_RX 7 E07
+resource SERIAL_TX 7 E08
 resource I2C_SCL 1 B06
 resource I2C_SDA 1 B07
 resource LED 1 A02


### PR DESCRIPTION
JHEMCU F745 FC missing uart7 TX pad, added it. No resource conflicts.