### PR TITLE
TUNERCF405 config "Dshot_bitbang" is changed from "AUTO" to "ON".

### DIFF
--- a/configs/default/TURC-TUNERCF405.config
+++ b/configs/default/TURC-TUNERCF405.config
@@ -95,6 +95,7 @@ feature OSD
 set serialrx_provider = CRSF
 set blackbox_device = SPIFLASH
 set dshot_burst = ON
+set dshot_bitbang = ON
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC
 set battery_meter = ADC

--- a/configs/default/TURC-TUNERCF405.config
+++ b/configs/default/TURC-TUNERCF405.config
@@ -1,5 +1,12 @@
 # Betaflight / STM32F405 (S405) 4.3.0 Jun 14 2022 / 00:47:24 (229ac66) MSP API: 1.44
 
+#define USE_ACCGYRO_BMI270
+#define USE_BARO_BMP280
+#define USE_BARO_SPI_BMP280
+#define USE_BARO_DPS310
+#define USE_BARO_SPI_DPS310
+#define USE_FLASH_W25Q128FV
+
 board_name TUNERCF405
 manufacturer_id TURC
 


### PR DESCRIPTION
"Dshot_bitbang" is changed from "AUTO" to "ON". This change is made to solve the issue that when Bidirectional Dshot is disabled, the LED strip would also be disabled, which would result in the LED not functioning.