### PR TITLE
Diatone H743: improve mag i2c settings, add #define properties

### DIFF
--- a/configs/default/DIAT-MAMBAH743.config
+++ b/configs/default/DIAT-MAMBAH743.config
@@ -141,6 +141,8 @@ serial 7 0 115200 57600 0 115200
 
 set baro_bustype = I2C
 set baro_i2c_device = 1
+set mag_bustype = I2C
+set mag_i2c_device = 1
 set sdcard_mode = OFF
 set flash_spi_bus = 3
 set blackbox_device = SPIFLASH

--- a/configs/default/DIAT-MAMBAH743.config
+++ b/configs/default/DIAT-MAMBAH743.config
@@ -3,6 +3,16 @@
 board_name MAMBAH743
 manufacturer_id DIAT
 
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
+#define USE_ACCGYRO_BMI270
+#define USE_MAG_LIS3MDL
+#define USE_MAG_AK8963
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_BARO_DPS310
+#define USE_MAX7456
+
 # resources
 resource BEEPER 1 E03
 resource MOTOR 1 A00

--- a/configs/default/DIAT-MAMBAH743.config
+++ b/configs/default/DIAT-MAMBAH743.config
@@ -6,10 +6,6 @@ manufacturer_id DIAT
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_ACCGYRO_BMI270
-#define USE_MAG_LIS3MDL
-#define USE_MAG_AK8963
-#define USE_MAG_HMC5883
-#define USE_MAG_QMC5883
 #define USE_BARO_DPS310
 #define USE_MAX7456
 


### PR DESCRIPTION
Seems like the I2C bus that is exposed on the PCB is `1` and not `0`, also the mag device needs to be set to `I2C` in order to work plug-and-play like with the usual hardware we use.
I tested this on my hardware successfully with the Matek M10-5883 which has the QMC5883 mag.