### PR TITLE
Update HAMO-CRAZYBEEF4SX1280.config

### DIFF
--- a/configs/default/HAMO-CRAZYBEEF4SX1280.config
+++ b/configs/default/HAMO-CRAZYBEEF4SX1280.config
@@ -12,6 +12,8 @@
 #define USE_RX_EXPRESSLRS_TELEMETRY
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
+#define USE_FLASH_W25M
+#define USE_FLASH_W25Q128FV 
 
 board_name CRAZYBEEF4SX1280
 manufacturer_id HAMO


### PR DESCRIPTION
Adding flash support. Noting this target is used by 

https://www.happymodel.cn/index.php/2022/06/11/pancake-2-6s-aio-f4-flight-controller-built-in-spi-elrs-2-4g-and-400mw-openvtx-compatible-with-20x20-and-35-5x35-5-stack/21-7/

Which may need its own target if this flash chip is not standard on CRAZYBEE boards.
