### PR TITLE
Default defines for gyro  / acc for DIAT-MAMBAF405US_I2C

### DIFF
--- a/configs/default/DIAT-MAMBAF405US_I2C.config
+++ b/configs/default/DIAT-MAMBAF405US_I2C.config
@@ -1,5 +1,13 @@
 # Betaflight / STM32F405 (S405) 4.1.0 Oct 16 2019 / 11:57:16 (c37a7c91a) MSP API: 1.42
 
+# some default defines until we know what is on the board.
+#define USE_ACC_MPU6500
+#define USE_GYRO_MPU6500
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
 board_name MAMBAF405US_I2C
 manufacturer_id DIAT
 


### PR DESCRIPTION
These maybe incorrect