### PR TITLE
Fix MAMBAF722_2022 (mk4) UART VTX port

### DIFF
--- a/configs/default/DIAT-MAMBAF722_2022A.config
+++ b/configs/default/DIAT-MAMBAF722_2022A.config
@@ -107,7 +107,7 @@ feature OSD
 
 # serial
 serial 0 64 115200 57600 0 115200
-serial 3 1 115200 57600 0 115200
+serial 2 1 115200 57600 0 115200
 
 # EXTRAS
 resource PINIO 1 C02

--- a/configs/default/DIAT-MAMBAF722_2022B.config
+++ b/configs/default/DIAT-MAMBAF722_2022B.config
@@ -111,7 +111,7 @@ feature OSD
 
 # serial
 serial 0 64 115200 57600 0 115200
-serial 3 1 115200 57600 0 115200
+serial 2 1 115200 57600 0 115200
 
 # master
 set mag_bustype = I2C


### PR DESCRIPTION
This almost gave me a heart attack thinking the new Vista is broken. :laughing: 

Turns out the serial port is wrong. It is UART3 instead of UART4. After that the Vista connection worked. The wiring diagram agrees.

I only changed `MAMBAF722_2022A` and `B` and not base `DIAT-MAMBAF722` as I am unsure about previous revisions. 

Official Wiring Diagram:
https://cdn.shopifycdn.net/s/files/1/0027/2708/4144/files/MK4_F722_MINI_42688P_-01.jpg