### PR TITLE
Add Cloud Defines for JHEH743_AIO

### DIFF
--- a/configs/default/JHEF-JHEH743_AIO.config
+++ b/configs/default/JHEF-JHEH743_AIO.config
@@ -1,5 +1,11 @@
 # Betaflight / STM32H743 (SH47) 4.3.0 Sep  2 2021 / 06:34:37 (c23dd47f4) MSP API: 1.44
 
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_BARO_BMP280
+#define USE_MAX7456
+#define USE_FLASH_M25P16
+
 board_name JHEH743_AIO
 manufacturer_id JHEF
 


### PR DESCRIPTION
Adding cloud defines for gyro, baro, flash, OSD and LED features onboard this AIO.