### PR TITLE
Update FOXE-FOXEERH743.config

### DIFF
--- a/configs/default/FOXE-FOXEERH743.config
+++ b/configs/default/FOXE-FOXEERH743.config
@@ -146,6 +146,7 @@ set beeper_inversion = ON
 set beeper_od = OFF
 set max7456_spi_bus = 1
 set flash_spi_bus = 3
+set sdcard_mode = OFF
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 2
 set gyro_1_sensor_align = CW0


### PR DESCRIPTION
parameter sdcard_mode was set to SDIO by default. This will cause the onboard SD card to be displayed on the betaflight configurator.
