### PR TITLE
Added JHEF745 defines

### DIFF
--- a/configs/default/JHEF-JHEF745.config
+++ b/configs/default/JHEF-JHEF745.config
@@ -1,5 +1,11 @@
 # Betaflight / STM32F745 (S745) 4.2.0 Jun 14 2020 / 03:05:04 (8f2d21460) MSP API: 1.43
 
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6000
+#define USE_BARO_BMP280
+#define USE_MAX7456
+#define USE_FLASH_M25P16
+
 board_name JHEF745
 manufacturer_id JHEF
 


### PR DESCRIPTION
Added gyro, accel, baro and flash details. Don't own the board but flash is visible as Winbond W25Q128 in photos. 

MPU6000, AT7456 and BMP280 listed in product specs.

