### PR TITLE
add DPS310 baro define to SPBE405v3

### DIFF
--- a/configs/default/SPBE-SPEEDYBEEF405V3.config
+++ b/configs/default/SPBE-SPEEDYBEEF405V3.config
@@ -3,6 +3,7 @@
 #define USE_ACCGYRO_BMI270
 #define USE_MAX7456
 #define USE_SDCARD
+#define USE_BARO_DPS310
 
 board_name SPEEDYBEEF405V3
 manufacturer_id SPBE


### PR DESCRIPTION
status output
```
MCU F40X Clock=168MHz (PLLP-HSE), Vref=3.29V, Core temp=39degC
Stack size: 2048, Stack address: 0x1000fff0
Configuration: CONFIGURED, size: 4100, max available: 16384
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked dma
GYRO=BMI270, ACC=BMI270, BARO=DPS310
OSD: MAX7456
System Uptime: 17 seconds, Current Time: 2023-01-04T16:08:09.695+00:00
CPU:15%, cycle time: 314, GYRO rate: 3184, RX rate: 15, System rate: 9
Voltage: 3 * 0.01V (0S battery - NOT PRESENT)
I2C Errors: 0
SD card: Startup failed
Arming disable flags: RXLOSS CLI MSP MOTOR_PROTO
```