### PR TITLE
Add DPS310 to MAMBAF722_2022A

### DIFF
--- a/configs/default/DIAT-MAMBAF722_2022A.config
+++ b/configs/default/DIAT-MAMBAF722_2022A.config
@@ -5,6 +5,7 @@
 #define USE_ACCGYRO_BMI270
 #define USE_FLASH_M25P16
 #define USE_MAX7456
+#define USE_BARO_DPS310
 
 board_name MAMBAF722_2022A
 manufacturer_id DIAT


### PR DESCRIPTION
# status
MCU F722 Clock=216MHz, Vref=3.26V, Core temp=44degC
Stack size: 2048, Stack address: 0x20010000
Configuration: CONFIGURED, size: 4140, max available: 16384
Devices detected: SPI:1, I2C:1
Gyros detected: gyro 1 locked dma
GYRO=BMI270, ACC=BMI270, BARO=DPS310
OSD: MAX7456 (30 x 13)
BUILD KEY: 4.4.0-RC3/MAMBAF722_2022A/8e7c13cab1069c62aa0406243c4a363c 
