### PR TITLE
MTKS-MATEKF405TE has onboard FLASH, not SD

### DIFF
--- a/configs/default/MTKS-MATEKF405TE.config
+++ b/configs/default/MTKS-MATEKF405TE.config
@@ -4,7 +4,7 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_BARO_DPS310
 #define USE_MAX7456
-#define USE_SDCARD
+#define USE_FLASH_M25P16
 
 board_name MATEKF405TE
 manufacturer_id MTKS


### PR DESCRIPTION
FLASH was not appearing using cloud build.