### PR TITLE
Add baro defines for Aocodarc targets

### DIFF
--- a/configs/default/SJET-AOCODAF405V2MPU6000.config
+++ b/configs/default/SJET-AOCODAF405V2MPU6000.config
@@ -2,6 +2,7 @@
 
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
+#define USE_BARO_BMP280
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 

--- a/configs/default/SJET-AOCODAF405V2MPU6500.config
+++ b/configs/default/SJET-AOCODAF405V2MPU6500.config
@@ -2,6 +2,7 @@
 
 #define USE_GYRO_SPI_MPU6500
 #define USE_ACC_SPI_MPU6500
+#define USE_BARO_BMP280
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 

--- a/configs/default/SJET-AOCODARCH7DUAL.config
+++ b/configs/default/SJET-AOCODARCH7DUAL.config
@@ -1,6 +1,7 @@
 # Betaflight / STM32H743 (SH74) 4.3.0 Feb  1 2022 / 20:15:46 (3267f0417) MSP API: 1.44
 
 #define USE_ACCGYRO_BMI270
+#define USE_BARO_DPS310
 #define USE_FLASH_W25N01G
 #define USE_MAX7456
 


### PR DESCRIPTION
I have these two fc and they are working with these definitions. The H7 may use the MS5611 and the BMP280 but I didn't want to add them since I just found this information on the internet.