### PR TITLE
Update HENA-TALONF7V2.config

### DIFF
--- a/configs/default/HENA-TALONF7V2.config
+++ b/configs/default/HENA-TALONF7V2.config
@@ -32,7 +32,7 @@ resource SERIAL_RX 4 A01
 resource SERIAL_RX 5 D02
 resource SERIAL_RX 6 C07
 resource LED 1 B00
-resource RX_BIND 1 B02
+resource RX_SPI_BIND 1 B02
 resource SPI_SCK 1 A05
 resource SPI_SCK 2 B13
 resource SPI_SCK 3 C10


### PR DESCRIPTION
RX_BIND is only for Spektrum. RX_SPI_BIND is for SPI receivers, that have a BIND option.
