### PR TITLE
SPRacingH7EXTREME - Fix unnecessary `=` symbol.

### DIFF
--- a/configs/default/SPRO-SPRACINGH7EXTREME.config
+++ b/configs/default/SPRO-SPRACINGH7EXTREME.config
@@ -10,7 +10,7 @@
 # a config from it can work. (SPI/QSPI/SDCARD).
 #
 
-#define EEPROM_SIZE = 8192
+#define EEPROM_SIZE 8192
 
 #define USE_SPRACING_PERSISTENT_RTC_WORKAROUND
 


### PR DESCRIPTION
History:

commit 3b25275019750cc3206af622648d077d7d9d8bc6 incorrectly had an equals, commit 9e432c5beff7fecdb989bfb3197a4ce94fd7f1a2 changed the spacing, but the correct fix is this PR.

FYI:

The inclusion of an `=` originally came from a copy/paste error from the build script in `support/scripts/build_spracingh7extreme.sh`.