### PR TITLE
Update GEPR-GEPRCF722_BT_HD.config

### DIFF
--- a/configs/default/GEPR-GEPRCF722_BT_HD.config
+++ b/configs/default/GEPR-GEPRCF722_BT_HD.config
@@ -2,6 +2,7 @@
 
 #define USE_ACC_SPI_ICM20689
 #define USE_GYRO_SPI_ICM20689
+#define USE_ACCGYRO_BMI270
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 
@@ -25,11 +26,13 @@ resource SERIAL_TX 2 A02
 resource SERIAL_TX 3 B10
 resource SERIAL_TX 4 C10
 resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 C06
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
 resource SERIAL_RX 3 B11
 resource SERIAL_RX 4 C11
 resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 C07
 resource I2C_SCL 2 B10
 resource I2C_SDA 2 B11
 resource LED 1 C04


### PR DESCRIPTION
Similar to the BT version, it has 6 uarts, and the BMI gyro
