### PR TITLE
Update SPRO-SPRACINGH7EXTREME.config

### DIFF
--- a/configs/default/SPRO-SPRACINGH7EXTREME.config
+++ b/configs/default/SPRO-SPRACINGH7EXTREME.config
@@ -81,8 +81,8 @@
 
 #define USE_I2C
 #define USE_I2C_DEVICE_1
-#define I2C1_SCL PB8
-#define I2C1_SDA PB9
+#define I2C1_SCL_PIN PB8
+#define I2C1_SDA_PIN PB9
 #define I2C_DEVICE (I2CDEV_1)
 
 


### PR DESCRIPTION
Adding _PIN to the I2C. Requires https://github.com/betaflight/betaflight/pull/12357
