### PR TITLE
Update SPRO-SPRACINGH7RF.config

### DIFF
--- a/configs/default/SPRO-SPRACINGH7RF.config
+++ b/configs/default/SPRO-SPRACINGH7RF.config
@@ -101,13 +101,13 @@
 #define USE_I2C
 # I2C1 for external MAG connection on J8, no pull-ups, external pull-ups REQUIRED.
 #define USE_I2C_DEVICE_1
-#define I2C1_SCL                PB8
-#define I2C1_SDA                PB9
+#define I2C1_SCL_PIN            PB8
+#define I2C1_SDA_PIN            PB9
 
 # I2C2 has BMP388 internally connected, 10k pull-ups
 #define USE_I2C_DEVICE_2
-#define I2C2_SCL                PB10
-#define I2C2_SDA                PB11
+#define I2C2_SCL_PIN            PB10
+#define I2C2_SDA_PIN            PB11
 
 #define MAG_I2C_INSTANCE        (I2CDEV_1)
 #define BARO_I2C_INSTANCE       (I2CDEV_2)


### PR DESCRIPTION
Adding _PIN to I2C definitions. Requires: https://github.com/betaflight/betaflight/pull/12357
