### PR TITLE
Fix invalid RX_SPI resources

### DIFF
--- a/configs/default/AFNG-ALIENFLIGHTNGF7_ELRS.config
+++ b/configs/default/AFNG-ALIENFLIGHTNGF7_ELRS.config
@@ -13,10 +13,16 @@
 #define USE_SDCARD
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB6
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PB7
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PB15
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PB9
 
 board_name ALIENFLIGHTNGF7_ELRS
 manufacturer_id AFNG

--- a/configs/default/BEFH-BETAFPVF4SX1280.config
+++ b/configs/default/BEFH-BETAFPVF4SX1280.config
@@ -11,8 +11,14 @@
 #define USE_RX_EXPRESSLRS_TELEMETRY
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB9
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC13
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name BETAFPVF4SX1280
 manufacturer_id BEFH

--- a/configs/default/DAFP-DARWINF4SX1280HD.config
+++ b/configs/default/DAFP-DARWINF4SX1280HD.config
@@ -13,13 +13,19 @@
 #define USE_GYRO_SPI_ICM42688P
 #define USE_ACC_SPI_ICM42605
 #define USE_ACC_SPI_ICM42688P
+#define USE_MAX7456
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_MAX7456
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB9
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC13
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name DARWINF4SX1280HD
 manufacturer_id DAFP

--- a/configs/default/EMAX-EMAX_TINYHAWKF4SX1280.config
+++ b/configs/default/EMAX-EMAX_TINYHAWKF4SX1280.config
@@ -7,12 +7,19 @@
 #define USE_ACC_SPI_ICM20689
 #define USE_ACC_SPI_ICM42688P
 #define USE_GYRO_SPI_ICM42688P
+#define USE_MAX7456
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
-#define USE_MAX7456
+#define RX_CHANNELS_AETR
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PA8
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC14
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PB9
 
 board_name EMAX_TINYHAWKF4SX1280
 manufacturer_id EMAX

--- a/configs/default/GEPR-GEPRCF411SX1280.config
+++ b/configs/default/GEPR-GEPRCF411SX1280.config
@@ -15,10 +15,16 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB9
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC13
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name GEPRCF411SX1280
 manufacturer_id GEPR

--- a/configs/default/HAMO-CRAZYBEEF4SX1280.config
+++ b/configs/default/HAMO-CRAZYBEEF4SX1280.config
@@ -8,15 +8,21 @@
 #define USE_ACCGYRO_BMI270
 #define USE_GYRO_SPI_ICM42688P
 #define USE_ACC_SPI_ICM42688P
+#define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 #define USE_RX_SPI
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_FLASH_W25Q128FV
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PA8
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC14
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PB9
 
 board_name CRAZYBEEF4SX1280
 manufacturer_id HAMO

--- a/configs/default/HGLR-HGLRCF411SX1280.config
+++ b/configs/default/HGLR-HGLRCF411SX1280.config
@@ -4,18 +4,23 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_GYRO_SPI_ICM42688P
 #define USE_ACCGYRO_BMI270
+#define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_FLASH_W25Q128FV
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB9
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC13
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name HGLRCF411SX1280
 manufacturer_id HGLR
-
 
 # resource
 resource BEEPER 1 A14

--- a/configs/default/IFRC-IFLIGHT_F4SX1280.config
+++ b/configs/default/IFRC-IFLIGHT_F4SX1280.config
@@ -3,13 +3,19 @@
 
 #define USE_ACCGYRO_BMI270
 #define USE_MAX7456
+#define USE_RX_SPI
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_RX_SPI
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PA8
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC14
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name IFLIGHT_F4SX1280
 manufacturer_id IFRC

--- a/configs/default/NERC-NEUTRONRCF411SX1280.config
+++ b/configs/default/NERC-NEUTRONRCF411SX1280.config
@@ -10,13 +10,19 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_GYRO_SPI_MPU6000
 #define USE_MAX7456
+#define USE_RX_SPI
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_RX_SPI
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PB9
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC13
+#define RX_SPI_BIND                     PB2
+#define RX_SPI_LED                      PC15
 
 board_name NEUTRONRCF411SX1280
 manufacturer_id NERC

--- a/configs/default/TMTR-TMOTORF4SX1280.config
+++ b/configs/default/TMTR-TMOTORF4SX1280.config
@@ -3,13 +3,19 @@
 
 #define USE_ACCGYRO_BMI270
 #define USE_MAX7456
+#define USE_RX_SPI
 #define USE_RX_EXPRESSLRS
 #define USE_RX_EXPRESSLRS_TELEMETRY
-#define RX_SPI_DEFAULT_PROTOCOL          RX_SPI_EXPRESSLRS
-#define RX_EXPRESSLRS_TIMER_INSTANCE     TIM5
 #define USE_RX_SX1280
 #define RX_CHANNELS_AETR
-#define USE_RX_SPI
+#define RX_SPI_DEFAULT_PROTOCOL         RX_SPI_EXPRESSLRS
+#define RX_EXPRESSLRS_TIMER_INSTANCE    TIM5
+#define RX_EXPRESSLRS_SPI_RESET_PIN     PA8
+#define RX_EXPRESSLRS_SPI_BUSY_PIN      PA13
+#define RX_SPI_CS                       PA15
+#define RX_SPI_EXTI                     PC14
+#define RX_SPI_BIND                     PB10
+#define RX_SPI_LED                      PA14
 
 board_name TMOTORF4SX1280
 manufacturer_id TMTR


### PR DESCRIPTION
Fixes:
```
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_CS'###
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_EXTI'###
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_BIND'###
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_LED'###
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_EXPRESSLRS_RESET'###
###ERROR IN resource: INVALID RESOURCE NAME: 'RX_SPI_EXPRESSLRS_BUSY'###
###ERROR IN set: INVALID NAME: rx_spi_bus = 3###
###ERROR IN set: INVALID NAME: rx_spi_led_inversion = ON###
```