### PR TITLE
Modify MatekF405TE series targets

### DIFF
--- a/configs/default/MTKS-MATEKF405TE.config
+++ b/configs/default/MTKS-MATEKF405TE.config
@@ -4,7 +4,7 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_BARO_DPS310
 #define USE_MAX7456
-#define USE_SDCARD
+#define USE_FLASH_M25P16
 
 board_name MATEKF405TE
 manufacturer_id MTKS
@@ -137,10 +137,10 @@ set ibata_scale = 150
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
-set blackbox_device = SPIFLASH
 set max7456_spi_bus = 1
 set pinio_box = 40,41,255,255
 set flash_spi_bus = 2
+set blackbox_device = SPIFLASH
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270FLIP

--- a/configs/default/MTKS-MATEKF405TE_SD.config
+++ b/configs/default/MTKS-MATEKF405TE_SD.config
@@ -4,9 +4,9 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_BARO_DPS310
 #define USE_MAX7456
-#define USE_FLASH_M25P16
+#define USE_SDCARD
 
-board_name MATEKF405TEMINI
+board_name MATEKF405TE_SD
 manufacturer_id MTKS
 
 # resources
@@ -137,10 +137,10 @@ set ibata_scale = 150
 set beeper_inversion = ON
 set beeper_od = OFF
 set system_hse_mhz = 8
-set blackbox_device = SPIFLASH
 set max7456_spi_bus = 1
 set pinio_box = 40,41,255,255
-set flash_spi_bus = 2
+set sdcard_spi_bus = 2
+set blackbox_device = SDCARD
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270FLIP

--- a/configs/default/MTKS-MATEKF405TE_SD.config
+++ b/configs/default/MTKS-MATEKF405TE_SD.config
@@ -139,6 +139,7 @@ set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 1
 set pinio_box = 40,41,255,255
+set sdcard_mode = SPI
 set sdcard_spi_bus = 2
 set blackbox_device = SDCARD
 set gyro_1_bustype = SPI


### PR DESCRIPTION
Previous MatekF405TE and MatekF405TEMINI both don't have SD card definitions.
Rename MatekF405TEMINI with MatekF405TE_SD,  unify the naming with INAV MatekF405TE & MatekF405TE_SD targets