### PR TITLE
CLRACINGF4 add W25Q128FV

### DIFF
--- a/configs/default/CLRA-CLRACINGF4.config
+++ b/configs/default/CLRA-CLRACINGF4.config
@@ -6,6 +6,7 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_MAX7456
 #define USE_SDCARD
+#define USE_FLASH_W25Q128FV
 
 board_name CLRACINGF4
 manufacturer_id CLRA


### PR DESCRIPTION
for the bardwell F4.
Not sure if we should make a clone config or not for this as I believe the FC is designed by the same person that designed the clracing FC so it's not really a clone.
Maybe it should have it's own config, but I'm not sure who's the manufacturer here. Is it JB? RDQ? clracing? lol