### PR TITLE
Update NEBD-NBD_INFINITYAIOV2.config

### DIFF
--- a/configs/default/NEBD-NBD_INFINITYAIOV2.config
+++ b/configs/default/NEBD-NBD_INFINITYAIOV2.config
@@ -1,5 +1,9 @@
 # Betaflight / STM32F745 (S745) 4.2.11 Nov  9 2021 / 20:29:04 (948ba6339) MSP API: 1.43
 
+#define USE_ACCGYRO_BMI270
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
 board_name NBD_INFINITYAIOV2
 manufacturer_id NEBD
 


### PR DESCRIPTION
Adds missing defines to the NBD Infinity AIO V2 target. 
Tested and confirmed working on BF Discord: https://discord.com/channels/868013470023548938/868013470518505494/1080145224275345478
