### PR TITLE
Added USE_CAMERA_CONTROL to all foxeer boards

### DIFF
--- a/configs/default/FOXE-FOXEERF405.config
+++ b/configs/default/FOXE-FOXEERF405.config
@@ -7,6 +7,7 @@
 #define USE_FLASH_W25Q128FV
 #define USE_FLASH_M25P16
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF405
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF722DUAL.config
+++ b/configs/default/FOXE-FOXEERF722DUAL.config
@@ -6,6 +6,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF722DUAL
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF722V2.config
+++ b/configs/default/FOXE-FOXEERF722V2.config
@@ -4,6 +4,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF722V2
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF722V3.config
+++ b/configs/default/FOXE-FOXEERF722V3.config
@@ -5,6 +5,7 @@
 #define USE_ACCGYRO_BMI270
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF722V3
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF722V4.config
+++ b/configs/default/FOXE-FOXEERF722V4.config
@@ -7,6 +7,7 @@
 #define USE_BARO_DPS310
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF722V4
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF745V2_AIO.config
+++ b/configs/default/FOXE-FOXEERF745V2_AIO.config
@@ -3,6 +3,7 @@
 #define USE_ACCGYRO_BMI270
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF745V2_AIO
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF745V3_AIO.config
+++ b/configs/default/FOXE-FOXEERF745V3_AIO.config
@@ -4,6 +4,7 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF745V3_AIO
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERF745_AIO.config
+++ b/configs/default/FOXE-FOXEERF745_AIO.config
@@ -4,6 +4,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERF745_AIO
 manufacturer_id FOXE

--- a/configs/default/FOXE-FOXEERH743.config
+++ b/configs/default/FOXE-FOXEERH743.config
@@ -5,6 +5,7 @@
 #define USE_BARO_DPS310
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#define USE_CAMERA_CONTROL
 
 board_name FOXEERH743
 manufacturer_id FOXE


### PR DESCRIPTION
we have half of the all boards with `resource CAMERA_CONTROL`
but only a couple actually have 
`#define USE_CAMERA_CONTROL`
this causes error in CLI when resetting to defaults

This is a fix for just foxeer boards

@haslinghuis  @blckmn 