### PR TITLE
Added SUB250F411 target

### DIFF
--- a/configs/default/SU25-SUB250F411.config
+++ b/configs/default/SU25-SUB250F411.config
@@ -1,0 +1,108 @@
+# Betaflight / STM32F411 (S411) 4.3.2 Nov 28 2022 / 07:27:10 (60c9521) MSP API: 1.44
+
+#define USE_ACCGYRO_BMI270
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_BARO_DPS310
+#define USE_BARO_BMP280
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
+board_name SUB250F411
+manufacturer_id SU25
+
+# resources
+resource BEEPER 1 B02
+resource MOTOR 1 B04
+resource MOTOR 2 B05
+resource MOTOR 3 B06
+resource MOTOR 4 B07
+resource PPM 1 A03
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource INVERTER 2 C15
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 C13
+resource LED 2 C14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource ADC_BATT 1 B00
+resource ADC_CURR 1 B01
+resource PINIO 1 B10
+resource FLASH_CS 1 A00
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 A01
+resource GYRO_CS 1 A04
+
+# timer
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+
+# dma
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+
+# feature
+feature TELEMETRY
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set serialrx_provider = CRSF
+set blackbox_device = SPIFLASH
+set dshot_idle_value = 800
+set dshot_burst = AUTO
+set dshot_bitbang = OFF
+set motor_pwm_protocol = DSHOT300
+set align_board_yaw = 45
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 500
+set beeper_inversion = ON
+set beeper_od = OFF
+set pid_process_denom = 1
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set pinio_box = 40,255,255,255
+set flash_spi_bus = 2
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW270
+set gyro_1_align_yaw = 2700
+
+profile 0
+
+# profile 0
+set anti_gravity_gain = 0

--- a/configs/default/SU25-SUB250F411.config
+++ b/configs/default/SU25-SUB250F411.config
@@ -101,8 +101,3 @@ set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW270
 set gyro_1_align_yaw = 2700
-
-profile 0
-
-# profile 0
-set anti_gravity_gain = 0


### PR DESCRIPTION
I added SUB250F411 target, as it's a controller for BNF DSHOT it's already enabled and there are some settings (such as idle, antigravity and UARTs already in the config file).
