### PR TITLE
Add BARO_BMP280 to GEPRCF405

### DIFF
--- a/configs/default/GEPR-GEPRCF405.config
+++ b/configs/default/GEPR-GEPRCF405.config
@@ -1,6 +1,7 @@
 # Betaflight / STM32F405 (S405) 4.1.6 Apr 25 2020 / 05:11:18 (283bda8bf) MSP API: 1.42
 
 #define USE_ACC_SPI_MPU6000
+#define USE_BARO_BMP280
 #define USE_GYRO_SPI_MPU6000
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456


### PR DESCRIPTION
https://build.betaflight.com/api/support/0284c723-482d-4ae9-8f67-590feb4c67d7

Fixes: https://github.com/betaflight/betaflight/issues/12531
