### PR TITLE
Fix F411 PA10 Motor DMA Assignment

### DIFF
--- a/configs/default/EMAX-EMAX_BABYHAWK_II_HD.config
+++ b/configs/default/EMAX-EMAX_BABYHAWK_II_HD.config
@@ -84,8 +84,8 @@ dma pin A08 1
 # pin A08: DMA2 Stream 1 Channel 6
 dma pin A09 1
 # pin A09: DMA2 Stream 2 Channel 6
-dma pin A10 0
-# pin A10: DMA2 Stream 6 Channel 0
+dma pin A10 1
+# pin A10: DMA2 Stream 6 Channel 6
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 dma pin B04 0

--- a/configs/default/FLWO-FLYWOOF411.config
+++ b/configs/default/FLWO-FLYWOOF411.config
@@ -76,8 +76,8 @@ dma pin A08 1
 # pin A08: DMA2 Stream 1 Channel 6
 dma pin A09 1
 # pin A09: DMA2 Stream 2 Channel 6
-dma pin A10 0
-# pin A10: DMA2 Stream 6 Channel 0
+dma pin A10 1
+# pin A10: DMA2 Stream 6 Channel 6
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 dma pin B04 0

--- a/configs/default/FLWO-FLYWOOF411EVO_HD.config
+++ b/configs/default/FLWO-FLYWOOF411EVO_HD.config
@@ -67,8 +67,8 @@ dma pin A08 1
 # pin A08: DMA2 Stream 1 Channel 6
 dma pin A09 1
 # pin A09: DMA2 Stream 2 Channel 6
-dma pin A10 0
-# pin A10: DMA2 Stream 6 Channel 0
+dma pin A10 1
+# pin A10: DMA2 Stream 6 Channel 6
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 dma pin B04 0

--- a/configs/default/JHEF-JHEF411.config
+++ b/configs/default/JHEF-JHEF411.config
@@ -77,8 +77,8 @@ dma pin A08 1
 # pin A08: DMA2 Stream 1 Channel 6
 dma pin A09 1
 # pin A09: DMA2 Stream 2 Channel 6
-dma pin A10 0
-# pin A10: DMA2 Stream 6 Channel 0
+dma pin A10 1
+# pin A10: DMA2 Stream 6 Channel 6
 dma pin B00 0
 # pin B00: DMA1 Stream 7 Channel 5
 dma pin B04 0


### PR DESCRIPTION
Timer-based DShot does not work on F411 FCs that use pin A10 as a motor output when DMA2 Stream 6 Channel 0 is used for TIM1_CH3. Moving the DMA assignment to DMA2 Stream 6 Channel 6 fixes the issue.

Before this PR:
```
dma pin A10 0
# pin A10: DMA2 Stream 6 Channel 0
```

After this PR:
```
dma pin A10 1
# pin A10: DMA2 Stream 6 Channel 6
```

Tested and confirmed working on the JHEF-JHEF411 and EMAX-EMAX_BABYHAWK_II_HD targets, but looks like some Flywoo F411 targets are affected as well and are included.

Issue report and troubleshooting on Betaflight Discord: https://discord.com/channels/868013470023548938/924169080045445120/1086879396255776828

![image](https://user-images.githubusercontent.com/36753790/226825648-16d4ed31-e62d-422f-9815-b53f45a351da.png)
