### PR TITLE
Add missing rx_spi_bus config to SX1280 targets

### DIFF
--- a/configs/default/GEPR-GEPRCF411SX1280.config
+++ b/configs/default/GEPR-GEPRCF411SX1280.config
@@ -92,6 +92,8 @@ dma pin B07 0
 
 
 # master
+set rx_spi_bus = 3
+set rx_spi_led_inversion = ON
 set blackbox_device = SPIFLASH
 set dshot_burst = OFF
 set dshot_bitbang = OFF

--- a/configs/default/NERC-NEUTRONRCF411SX1280.config
+++ b/configs/default/NERC-NEUTRONRCF411SX1280.config
@@ -89,6 +89,8 @@ dma pin B07 0
 
 
 # master
+set rx_spi_bus = 3
+set rx_spi_led_inversion = ON
 set blackbox_device = SPIFLASH
 set dshot_burst = OFF
 set dshot_bitbang = OFF


### PR DESCRIPTION
These SX1280 targets did not have rx_spi_bus and rx_spi_led_inversion set, so the SPI receiver was not working after flashing (rx_spi_bus was set to 0). NeutronRCSX1280 target was missing this as well. 

Tested and working in the ELRS Discord when helping someone troubleshoot a GEPRCF411SX1280 FC ELRS SPI receiver not working: https://discord.com/channels/596350022191415318/798006228450017290/1088998533937516644