### PR TITLE
Update LMNR-LUXF4OSD.config

### DIFF
--- a/configs/default/LMNR-LUXF4OSD.config
+++ b/configs/default/LMNR-LUXF4OSD.config
@@ -5,6 +5,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_ACC_SPI_MPU6000
 #define USE_MAX7456
+#define USE_FLASH_W25Q128FV
 
 board_name LUXF4OSD
 manufacturer_id LMNR


### PR DESCRIPTION
Adds missing flash define for blackbox on this target. Confirmed working in support channel on BF Discord: https://discord.com/channels/868013470023548938/924169080045445120/1092145727473459220

