### PR TITLE
Add ESCSERIAL resource (MAMBAF405US_I2C).

### DIFF
--- a/configs/default/DIAT-MAMBAF405US_I2C.config
+++ b/configs/default/DIAT-MAMBAF405US_I2C.config
@@ -123,6 +123,7 @@ serial 3 1 115200 57600 0 115200
 
 # EXTRAS
 resource INVERTER 1 C00
+resource ESCSERIAL 1 B09
 resource PINIO 1 B00
 
 # master


### PR DESCRIPTION
Enable "escprog" CLI command for MAMBAF405US_I2C. Works as expected. Tested with ESCape32 esc firmware (https://github.com/neoxic/ESCape32).