### PR TITLE
Remove gyro alignment LMNR-LUXMINIF7

### DIFF
--- a/configs/default/LMNR-LUXMINIF7.config
+++ b/configs/default/LMNR-LUXMINIF7.config
@@ -106,5 +106,4 @@ set pinio_box = 40,255,255,255
 set flash_spi_bus = 2
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
-set gyro_1_sensor_align = CW180
 set gyro_1_align_yaw = 1800


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/12829

CW0 = default
