### PR TITLE
Update FOXE-FOXEERF745V4_AIO.config

### DIFF
--- a/configs/default/FOXE-FOXEERF745V4_AIO.config
+++ b/configs/default/FOXE-FOXEERF745V4_AIO.config
@@ -102,7 +102,6 @@ set mag_i2c_device = 1
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set serialrx_provider = SBUS
-set adc_device = 3
 set blackbox_device = SPIFLASH
 set motor_pwm_protocol = DSHOT600
 set current_meter = ADC


### PR DESCRIPTION
removing setting stopping the voltage and current ADCs from working

tested on foxeer v4 reaper AIO