### PR TITLE
SPRacingH7RF - Fix incorrect button pin definition.

### DIFF
--- a/configs/default/SPRO-SPRACINGH7RF.config
+++ b/configs/default/SPRO-SPRACINGH7RF.config
@@ -17,9 +17,9 @@
 #define USE_SPRACING_PERSISTENT_RTC_WORKAROUND
 
 #define USE_BUTTONS
-#define BUTTON_A_PIN            PE4
+#define BUTTON_A_PIN            PC14
 #define BUTTON_A_PIN_INVERTED
-#define BUTTON_B_PIN            PE4
+#define BUTTON_B_PIN            PC14
 #define BUTTON_B_PIN_INVERTED
 
 #define USE_OCTOSPI

--- a/configs/default/SPRO-SPRACINGH7RF.config
+++ b/configs/default/SPRO-SPRACINGH7RF.config
@@ -306,6 +306,9 @@ feature LED_STRIP
 feature TELEMETRY
 feature RX_SPI
 
+set beeper_inversion = ON
+set beeper_od = OFF
+
 set mag_bustype = I2C
 set mag_i2c_device = 1
 


### PR DESCRIPTION
* It was conflicting with the beeper, causing a lock-up on boot.
