### PR TITLE
Modify the resource configuration of the BEFH-BETAFPVF411RX target

### DIFF
--- a/configs/default/BEFH-BETAFPVF411RX.config
+++ b/configs/default/BEFH-BETAFPVF411RX.config
@@ -16,6 +16,7 @@ board_name BETAFPVF411RX
 manufacturer_id BEFH
 
 # resources
+resource BEEPER 1 A14
 resource MOTOR 1 B08
 resource MOTOR 2 A00
 resource MOTOR 3 B10
@@ -43,9 +44,6 @@ resource RX_SPI_CS 1 A15
 resource RX_SPI_EXTI 1 C13
 resource RX_SPI_BIND 1 B02
 resource RX_SPI_LED 1 C15
-resource RX_SPI_CC2500_TX_EN 1 B09
-resource RX_SPI_CC2500_LNA_EN 1 A13
-resource RX_SPI_CC2500_ANT_SEL 1 A14
 resource GYRO_EXTI 1 B06
 resource GYRO_CS 1 A04
 resource FLASH_CS 1 A08
@@ -98,6 +96,8 @@ set dshot_bitbang = OFF
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set cc2500_spi_chip_detect = OFF


### PR DESCRIPTION
This target never used an LNA, a buzzer control is designed into some boards.
Request to release LNA control resources and add buzzer control resources.

[F4 1S 12A AIO SPI Frsky](https://betafpv.com/collections/brushless-flight-controller/products/f4-1s-12a-flight-controller?variant=39921521524870)

#1035 