### PR TITLE
add uart3 to geprcf722

### DIFF
--- a/configs/default/GEPR-GEPRCF722.config
+++ b/configs/default/GEPR-GEPRCF722.config
@@ -28,10 +28,12 @@ resource PWM 1 A02
 resource LED_STRIP 1 A08
 resource SERIAL_TX 1 A09
 resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
 resource SERIAL_TX 4 A00
 resource SERIAL_TX 6 C06
 resource SERIAL_RX 1 A10
 resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
 resource SERIAL_RX 4 A01
 resource SERIAL_RX 6 C07
 resource I2C_SCL 1 B08


### PR DESCRIPTION
Hi,

this PR adds UART3 to be usable on this target.

KR
David