### PR TITLE
Only few with #wiki string left over

### DIFF
--- a/configs/default/FRSK-FRSKYF4.config
+++ b/configs/default/FRSK-FRSKYF4.config
@@ -1,7 +1,6 @@
 # Betaflight / STM32F405 (S405) 4.2.0 Dec  6 2019 / 00:42:14 (b18478f43e) MSP API: 1.43
 
 #mcu STM32F405
-#wiki https://github.com/betaflight.com/docs/boards/FRSKYF4
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000

--- a/configs/default/HBRO-KAKUTEF7.config
+++ b/configs/default/HBRO-KAKUTEF7.config
@@ -1,7 +1,7 @@
 # Betaflight / STM32F745 (S745) 4.0.0 Apr  3 2019 / 14:32:23 (22b9f3453) MSP API: 1.41
 
 #mcu STM32F745
-#wiki https://betaflight.com/docs/boards/KAKUTEF7
+#wiki https://betaflight.com/docs/wiki/boards/KAKUTEF7
 
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM20689

--- a/configs/default/HBRO-KAKUTEF7V2.config
+++ b/configs/default/HBRO-KAKUTEF7V2.config
@@ -1,7 +1,6 @@
 # Betaflight / STM32F745 (S745) 4.2.0 Feb  2 2020 / 16:59:28 (norevision) MSP API: 1.43
 
 #mcu STM32F745
-#wiki https://betaflight.com/docs/boards/KAKUTEF7V2
 
 #define USE_ACC
 #define USE_ACC_SPI_ICM20689

--- a/configs/default/HBRO-KAKUTEH7.config
+++ b/configs/default/HBRO-KAKUTEH7.config
@@ -1,7 +1,7 @@
 # Betaflight / STM32H743 (SH74) 4.3.0 Aug 10 2021 / 12:14:35 (8ca4fdc58) MSP API: 1.44
 
 #mcu STM32H743
-#wiki https://betaflight.com/docs/boards/KAKUTEH7
+#wiki https://betaflight.com/docs/wiki/boards/KAKUTEH7
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000

--- a/configs/default/HBRO-KAKUTEH7V2.config
+++ b/configs/default/HBRO-KAKUTEH7V2.config
@@ -1,7 +1,6 @@
 # Betaflight / STM32H743 (SH74) 4.3.0 Apr 25 2022 / 01:08:20 (9d71184) MSP API: 1.44
 
 #mcu STM32H743
-#wiki https://betaflight.com/docs/boards/KAKUTEH7V2
 
 #define USE_ACC
 #define USE_GYRO

--- a/configs/default/SDRC-SDMODELH7V1.config
+++ b/configs/default/SDRC-SDMODELH7V1.config
@@ -1,7 +1,6 @@
 # Betaflight / STM32H743 (SH74) 4.3.0 Jun 1 2023 / 01:08:20 (9d71184) MSP API: 1.44
 
 #mcu STM32H743
-#wiki https://betaflight.com/docs/boards/SDMODELH7V1
 
 #define USE_ACC
 #define USE_GYRO


### PR DESCRIPTION
remove #wiki in most files, but HBRO-KAKUTEF4.config, HBRO-KAKUTEF7.config and HBRO-KAKUTEH7.config
Link in files are https://betaflight.com/docs/wiki/boards/KAKUTExx