### PR TITLE
GEPRCF405 internal Baro fix

### DIFF
--- a/configs/default/GEPR-GEPRCF405.config
+++ b/configs/default/GEPR-GEPRCF405.config
@@ -129,7 +129,8 @@ aux 0 0 0 1700 2100 0 0
 set mag_bustype = I2C
 set mag_i2c_device = 1
 set baro_bustype = I2C
-set baro_i2c_device = 1
+// Internal BMP280 is on I2C_2 (SCL B10; SDA B11)
+set baro_i2c_device = 2
 set serialrx_provider = SBUS
 set blackbox_device = SPIFLASH
 set motor_pwm_protocol = DSHOT600


### PR DESCRIPTION
There is a fault inside the BF target. Internal BMP280 is connected to I²C_2 (SCL PB10; SDA PB11).
