### PR TITLE
added MEPS Manufacturer

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -57,6 +57,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |LDAR|LDARC|http://ldarc.com/|
 |LMNR|Lumenier|https://www.lumenier.com/|
 |MARC|Mayhem RC|https://mayhemrc.com.au/|
+|MEPS|MepsKing|https://www.mepsking.com/|
 |MERA|MerakRC|http://www.merakrc.com/|
 |MOLA|MotoLab|https://github.com/MotoLab|
 |MOQU|Modd Quad|https://www.moddquad.com/|


### PR DESCRIPTION
[added MEPS Manufacturer](https://github.com/betaflight/unified-targets/pull/1176) #1176

Reopened from MEPS branch