### PR TITLE
Set board align 45 degrees

### DIFF
--- a/configs/default/SKST-SKYSTARSF405AIO.config
+++ b/configs/default/SKST-SKYSTARSF405AIO.config
@@ -121,3 +121,4 @@ set gyro_1_align_yaw = 450
 set current_meter = ADC
 set battery_meter = ADC
 set ibata_scale = 558
+set align_board_yaw = 45


### PR DESCRIPTION
Set alignment offset to 45 degrees by default as requested by manufacturer.