### PR TITLE
Rename FLWO-FLYWOOF745AIOV2.config to FLWO-FLYWOOF745AIO.config

### DIFF
--- a/configs/default/FLWO-FLYWOOF745AIO.config
+++ b/configs/default/FLWO-FLYWOOF745AIO.config
@@ -11,7 +11,7 @@
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
 
-board_name FLYWOOF745AIOV2
+board_name FLYWOOF745AIO
 manufacturer_id FLWO
 
 # resources


### PR DESCRIPTION
Found out looking at cloud build issues as there is no V1 version and has this board name in config repo already.

