### PR TITLE
HGLRC: Add HGLRCF722MINIV2 board target

### DIFF
--- a/configs/default/HGLR-HGLRCF722MINIV2.config
+++ b/configs/default/HGLR-HGLRCF722MINIV2.config
@@ -1,0 +1,154 @@
+# Betaflight / STM32F7X2 (S7X2) 4.4.3 Nov 17 2023 / 05:45:22 (738127e7e) MSP API: 1.45
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM42688P
+#define USE_ACCGYRO_BMI270
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM42688P
+#define USE_MAX7456
+
+board_name HGLRCF722MINIV2
+manufacturer_id HGLR
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 B04
+resource MOTOR 2 B05
+resource MOTOR 3 B00
+resource MOTOR 4 B01
+resource MOTOR 5 A15
+resource MOTOR 6 B03
+resource MOTOR 7 B06
+resource MOTOR 8 B07
+resource LED_STRIP 1 A08
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 6 C07
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+resource LED 1 A14
+resource LED 2 A13
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource ADC_BATT 1 C02
+resource ADC_RSSI 1 C00
+resource ADC_CURR 1 C01
+resource BARO_CS 1 A04
+resource PINIO 1 C08
+resource PINIO 2 C09
+resource FLASH_CS 1 D02
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 B02
+resource USB_DETECT 1 C14
+
+# timer
+timer B04 AF2
+# pin B04: TIM3 CH1 (AF2)
+timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin B04 0
+# pin B04: DMA1 Stream 4 Channel 5
+dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
+dma pin A08 2
+# pin A08: DMA2 Stream 3 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+
+# feature
+feature OSD
+feature RX_SERIAL
+feature LED_STRIP
+
+# serial
+serial 20 1 115200 57600 0 115200
+serial 0 0 115200 57600 0 115200
+serial 1 0 115200 57600 0 115200
+serial 2 0 115200 57600 0 115200
+serial 3 0 115200 57600 0 115200
+
+# aux
+aux 1 1 1 1300 1700 0 0
+
+# master
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_i2c_address = 0
+set adc_device = 1
+set blackbox_device = SPIFLASH
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set vbat_scale = 110
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set max7456_spi_bus = 2
+set pinio_config = 1,1,1,1
+set pinio_box = 40,41,255,255
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW0


### PR DESCRIPTION
![image](https://github.com/betaflight/unified-targets/assets/10217966/126cb1cb-8467-411e-bd6a-36ac7f0f0114)

- Main control: STM32f722
- Gyroscope: MPU6000
- Barometer: DPS310
- Blackbox: 16MB
- 5v2a BEC
- 10v1.5A bec with electronic switch
- Second generation Bluetooth wireless parameter adjustment
- Built-in reconstruction, built-in capacitor, full in-line soldering of peripherals
- Analog HD 2-in-1 video interface

