### PR TITLE
fix define and i2c mag device

### DIFF
--- a/configs/default/DIAT-FURYF4OSD.config
+++ b/configs/default/DIAT-FURYF4OSD.config
@@ -12,7 +12,7 @@
 #define USE_GYRO_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP280
-#define USE_BARO_DSP310
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
@@ -109,7 +109,7 @@ set beeper_od = OFF
 set baro_bustype = I2C
 set baro_i2c_device = 1
 set mag_bustype = I2C
-set mag_i2c_address = 1
+set mag_i2c_device = 1
 set system_hse_mhz = 8
 set max7456_spi_bus = 2
 set dashboard_i2c_bus = 1


### PR DESCRIPTION
fixes typo in use baro define

fixes typo in mag_i2c config