### PR TITLE
PYDR-PYRODRONEF7 - add Timer and DMA missing comments

### DIFF
--- a/configs/default/PYDR-PYRODRONEF7.config
+++ b/configs/default/PYDR-PYRODRONEF7.config
@@ -56,36 +56,65 @@ resource USB_DETECT 1 C05
 
 # timer
 timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
 timer B00 AF1
+# pin B00: TIM1 CH2N (AF1)
 timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
 timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
 timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
 timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
 timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
 timer B05 AF2
+# pin B05: TIM3 CH2 (AF2)
 timer B09 AF2
+# pin B09: TIM4 CH4 (AF2)
 timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
 timer B03 AF1
+# pin B03: TIM2 CH2 (AF1)
 timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
 timer B07 AF2
+# pin B07: TIM4 CH2 (AF2)
 timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
 timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
 
 # dma
 dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
 dma pin B00 0
+# pin B00: DMA2 Stream 6 Channel 0
 dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
 dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
 dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
 dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
 dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
 dma pin B05 0
+# pin B05: DMA1 Stream 5 Channel 5
 dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
 dma pin B03 0
+# pin B03: DMA1 Stream 6 Channel 3
 dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
 dma pin B07 0
+# pin B07: DMA1 Stream 3 Channel 2
 dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
 dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
 
 # feature
 feature RX_SERIAL


### PR DESCRIPTION
- via `USE_TIMER_MAP_PRINT`
