### PR TITLE
OMNIBUSF4SD: Add support DPS310 sensor

### DIFF
--- a/configs/default/AIRB-OMNIBUSF4SD.config
+++ b/configs/default/AIRB-OMNIBUSF4SD.config
@@ -8,6 +8,7 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_BARO
 #define USE_BARO_SPI_BMP280
+#define USE_BARO_SPI_DPS310
 #define USE_MAX7456
 #define USE_SDCARD
 


### PR DESCRIPTION
Alleviating the out-of-stock problem of BMP280 sensors.