### PR TITLE
Update BKMN-NERO.config

### DIFF
--- a/configs/default/BKMN-NERO.config
+++ b/configs/default/BKMN-NERO.config
@@ -1,7 +1,7 @@
 # Betaflight / STM32F7X2 (S7X2) 4.4.3 Mar 18 2024 / 20:58:20 (738127e7e) MSP API: 1.45
 
-#define USE_GYRO
-#define USE_GYRO_SPI_ICM20602
+#define USE_ACC
+#define USE_ACC_SPI_ICM20602
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM20602
 #define USE_SDCARD


### PR DESCRIPTION
In the first commit I forgot to add the USE_ACC gyro definition, and this is throwing an error in the cloud build.

I corrected this now.

