### PR TITLE
Reassign Timer and dma of DAKEFPVF722 target

### DIFF
--- a/configs/default/DAKE-DAKEFPVF722.config
+++ b/configs/default/DAKE-DAKEFPVF722.config
@@ -73,10 +73,10 @@ timer A09 AF1
 # pin A09: TIM1 CH2 (AF1)
 timer A10 AF1
 # pin A10: TIM1 CH3 (AF1)
-timer B00 AF2
-# pin B00: TIM3 CH3 (AF2)
-timer B01 AF2
-# pin B01: TIM3 CH4 (AF2)
+timer B00 AF1
+# pin B00: TIM1 CH2N (AF1)
+timer B01 AF1
+# pin B01: TIM1 CH3N (AF1)
 timer B03 AF1
 # pin B03: TIM2 CH2 (AF1)
 timer B04 AF2
@@ -93,18 +93,18 @@ timer C09 AF3
 # dma
 dma ADC 2 1
 # ADC 2: DMA2 Stream 3 Channel 1
-dma pin B00 0
-# pin B00: DMA1 Stream 7 Channel 5
+dma pin B00 1
+# pin B00: DMA2 Stream 2 Channel 6
 dma pin B01 0
-# pin B01: DMA1 Stream 2 Channel 5
+# pin B01: DMA2 Stream 6 Channel 0
 dma pin B03 0
 # pin B03: DMA1 Stream 6 Channel 3
 dma pin B06 0
 # pin B06: DMA1 Stream 0 Channel 2
 dma pin B07 0
 # pin B07: DMA1 Stream 3 Channel 2
-dma pin C08 0
-# pin C08: DMA2 Stream 2 Channel 0
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
 dma pin C09 0
 # pin C09: DMA2 Stream 7 Channel 7
 


### PR DESCRIPTION
TIM1 is more suitable for S5/S6.

Please check. Thank you.