### PR TITLE
Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue

### DIFF
--- a/configs/default/SJET-AOCODARCH7DUAL.config
+++ b/configs/default/SJET-AOCODARCH7DUAL.config
@@ -24,10 +24,10 @@ resource MOTOR 1 B00
 resource MOTOR 2 B01
 resource MOTOR 3 A00
 resource MOTOR 4 A01
-resource MOTOR 5 A02
-resource MOTOR 6 A03
-resource MOTOR 7 D12
-resource MOTOR 8 D13
+resource MOTOR 5 D13
+resource MOTOR 6 D12
+resource MOTOR 7 A03
+resource MOTOR 8 A02
 resource SERVO 1 E05
 resource SERVO 2 E06
 resource PPM 1 A10


### PR DESCRIPTION
[ Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue #9948 ](https://github.com/iNavFlight/inav/pull/9948)