### PR TITLE
Update FPVM-FPVM_BETAFLIGHTF7.config

### DIFF
--- a/configs/default/FPVM-FPVM_BETAFLIGHTF7.config
+++ b/configs/default/FPVM-FPVM_BETAFLIGHTF7.config
@@ -7,6 +7,8 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_ACC_SPI_MPU6500
 #define USE_MAX7456
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
 
 board_name FPVM_BETAFLIGHTF7
 manufacturer_id FPVM


### PR DESCRIPTION
FC includes Winbond 25Q128JVSQ flash, but define is missing from target.  https://www.getfpv.com/betaflight-f7-flight-controller.html

Keep consistent with https://github.com/betaflight/config/pull/415
