### PR TITLE
Update HGLR-HGLRCF405V2.config

### DIFF
--- a/configs/default/HGLR-HGLRCF405V2.config
+++ b/configs/default/HGLR-HGLRCF405V2.config
@@ -2,8 +2,10 @@
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM42688P
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP280
 #define USE_BARO_DPS310


### PR DESCRIPTION
The latest FC contains the ICM42688P gyroscope, but the target lacks definitions. Add ICM42688P definitions