### PR TITLE
rename manufacturer id FLMO to STBE

### DIFF
--- a/configs/default/STBE-STELLARF4.config
+++ b/configs/default/STBE-STELLARF4.config
@@ -11,7 +11,7 @@
 #define USE_MAX7456
 
 board_name STELLARF4
-manufacturer_id FLMO
+manufacturer_id STBE
 
 # resources
 resource BEEPER 1 C05

--- a/configs/default/STBE-STELLARF7.config
+++ b/configs/default/STBE-STELLARF7.config
@@ -13,14 +13,14 @@
 #define USE_FLASH_M25P16
 #define USE_MAX7456
 
-board_name STELLARF7V2
-manufacturer_id FLMO
+board_name STELLARF7
+manufacturer_id STBE
 
 # resources
-resource MOTOR 1 C09
-resource MOTOR 2 C08
-resource MOTOR 3 C07
-resource MOTOR 4 C06
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 C08
+resource MOTOR 4 C09
 resource SERVO 1 B11
 resource SERVO 2 B10
 resource PPM 1 B07

--- a/configs/default/STBE-STELLARF7V2.config
+++ b/configs/default/STBE-STELLARF7V2.config
@@ -13,14 +13,14 @@
 #define USE_FLASH_M25P16
 #define USE_MAX7456
 
-board_name STELLARF7
-manufacturer_id FLMO
+board_name STELLARF7V2
+manufacturer_id STBE
 
 # resources
-resource MOTOR 1 C06
-resource MOTOR 2 C07
-resource MOTOR 3 C08
-resource MOTOR 4 C09
+resource MOTOR 1 C09
+resource MOTOR 2 C08
+resource MOTOR 3 C07
+resource MOTOR 4 C06
 resource SERVO 1 B11
 resource SERVO 2 B10
 resource PPM 1 B07


### PR DESCRIPTION
We have rebranded, new name StingBee
Renaming FLMO - FlyMod targets to STBE - StingBee